### PR TITLE
added semicolons to the static statements

### DIFF
--- a/src/components/PropertyLabelCell.js
+++ b/src/components/PropertyLabelCell.js
@@ -7,7 +7,7 @@ export default class PropertyLabelCell extends PureComponent {
 
   static propTypes = {
     propertyDescription: PropTypes.instanceOf( PropertyDescription ),
-  }
+  };
 
   render() {
     const { label, description, id } = this.props.propertyDescription;

--- a/src/components/PropertyLabelCellById.js
+++ b/src/components/PropertyLabelCellById.js
@@ -8,7 +8,7 @@ export default class PropertyLabelCellById extends PureComponent {
 
   static propTypes = {
     propertyId: PropTypes.string.isRequired,
-  }
+  };
 
   render() {
     const { propertyId } = this.props;

--- a/src/components/SnakEditorTableRowPart.js
+++ b/src/components/SnakEditorTableRowPart.js
@@ -22,7 +22,7 @@ export default class SnakEditorTableRowPart extends PureComponent {
       snaktype: 'value',
     },
     readOnly: false,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/SnakValueEditorFactory.js
+++ b/src/components/SnakValueEditorFactory.js
@@ -34,11 +34,11 @@ export default class SnakValueEditorFactory extends PureComponent {
     onSnakChange: PropTypes.func.isRequired,
     propertyDescription: PropTypes.instanceOf( PropertyDescription ).isRequired,
     snak: PropTypes.shape( Snak ),
-  }
+  };
 
   static defaultProps = {
     readOnly: false,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/Spinner.js
+++ b/src/components/Spinner.js
@@ -6,11 +6,11 @@ export default class Spinner extends PureComponent {
 
   static propTypes = {
     size: PropTypes.number,
-  }
+  };
 
   static defaultProps = {
     size: 50,
-  }
+  };
 
   render() {
     const { size, ...other } = this.props;

--- a/src/components/claims/ClaimsTableBody.js
+++ b/src/components/claims/ClaimsTableBody.js
@@ -21,7 +21,7 @@ export default class ClaimsTableBody extends PureComponent {
 
   static defaultProps = {
     displayLabel: true,
-  }
+  };
 
   render() {
     const { claims, displayLabel, propertyDescription,

--- a/src/components/claims/ClaimsTableRows.js
+++ b/src/components/claims/ClaimsTableRows.js
@@ -28,7 +28,7 @@ export default class ClaimsTableRows extends PureComponent {
 
   static defaultProps = {
     displayLabel: true,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/claims/PropertyClaimContainer.js
+++ b/src/components/claims/PropertyClaimContainer.js
@@ -23,7 +23,7 @@ class PropertyClaimContainer extends PureComponent {
 
   static defaultProps = {
     displayLabel: true,
-  }
+  };
 
   columnsMemoization = claimColumnsF();
 

--- a/src/components/dataValueEditors/MonolingualTextDataValueEditor.js
+++ b/src/components/dataValueEditors/MonolingualTextDataValueEditor.js
@@ -10,7 +10,7 @@ export default class MonolingualTextDataValueEditor extends PureComponent {
     datavalue: PropTypes.shape( Shapes.DataValue ),
     onDataValueChange: PropTypes.func.isRequired,
     readOnly: PropTypes.bool,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/dataValueEditors/UnsupportedDataValueEditor.js
+++ b/src/components/dataValueEditors/UnsupportedDataValueEditor.js
@@ -10,7 +10,7 @@ export default class UnsupportedDataValueEditor extends Component {
   static propTypes = {
     datavalue: PropTypes.shape( Shapes.DataValue ),
     propertyDescription: PropTypes.instanceOf( PropertyDescription ),
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/dataValueEditors/external-id/SearchOnSourceWebsitesButtonCell.js
+++ b/src/components/dataValueEditors/external-id/SearchOnSourceWebsitesButtonCell.js
@@ -16,7 +16,7 @@ class SearchOnSourceWebsitesButtonCell extends PureComponent {
     labels: PropTypes.object,
     languageCodes: PropTypes.arrayOf( PropTypes.string ).isRequired,
     sourceWebsites: PropTypes.arrayOf( PropTypes.string ).isRequired,
-  }
+  };
 
   memoizeUrl = defaultMemoize( ( labels, languageCodes, sourceWebsites ) => {
     const languageSet = new Set( languageCodes );

--- a/src/components/dataValueEditors/quantity/BoundariesValueEditor.js
+++ b/src/components/dataValueEditors/quantity/BoundariesValueEditor.js
@@ -7,12 +7,12 @@ export default class BoundariesValueEditor extends PureComponent {
     onValueChange: PropTypes.func.isRequired,
     readOnly: PropTypes.bool,
     value: PropTypes.object,
-  }
+  };
 
   static defaultProps = {
     value: null,
     readOnly: false,
-  }
+  };
 
   static canBeUsedForValue() {
     return true;

--- a/src/components/dataValueEditors/quantity/ExactValueEditor.js
+++ b/src/components/dataValueEditors/quantity/ExactValueEditor.js
@@ -9,12 +9,12 @@ export default class ExactValueEditor extends PureComponent {
     onValueChange: PropTypes.func.isRequired,
     readOnly: PropTypes.bool,
     value: PropTypes.object,
-  }
+  };
 
   static defaultProps = {
     value: {},
     readOnly: false,
-  }
+  };
 
   static canBeUsedForValue( value ) {
     const { amount, lowerBound, upperBound } = value;

--- a/src/components/dataValueEditors/quantity/ModeSelect.js
+++ b/src/components/dataValueEditors/quantity/ModeSelect.js
@@ -11,7 +11,7 @@ export default class ModeSelect extends PureComponent {
     mode: PropTypes.string.isRequired,
     onSelect: PropTypes.func.isRequired,
     value: PropTypes.object,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/dataValueEditors/quantity/PlusMinusValueEditor.js
+++ b/src/components/dataValueEditors/quantity/PlusMinusValueEditor.js
@@ -10,12 +10,12 @@ export default class PlusMinusValueEditor extends PureComponent {
     onValueChange: PropTypes.func.isRequired,
     readOnly: PropTypes.bool,
     value: PropTypes.object,
-  }
+  };
 
   static defaultProps = {
     value: null,
     readOnly: false,
-  }
+  };
 
   static canBeUsedForValue( value ) {
     const { amount, lowerBound, upperBound } = value || {};

--- a/src/components/dataValueEditors/quantity/QuantityDataValueEditor.js
+++ b/src/components/dataValueEditors/quantity/QuantityDataValueEditor.js
@@ -34,11 +34,11 @@ export default class QuantityDataValueEditor extends PureComponent {
     onDataValueChange: PropTypes.func.isRequired,
     propertyDescription: PropTypes.instanceOf( PropertyDescription ),
     readOnly: PropTypes.bool,
-  }
+  };
 
   static defaultProps = {
     readOnly: false,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/dataValueEditors/quantity/UnitSelect.js
+++ b/src/components/dataValueEditors/quantity/UnitSelect.js
@@ -12,7 +12,7 @@ export default class UnitSelect extends PureComponent {
     propertyDescription: PropTypes.instanceOf( PropertyDescription ),
     onValueChange: PropTypes.func.isRequired,
     readOnly: PropTypes.bool,
-  }
+  };
 
   static defaultProps = {
     value: {
@@ -20,7 +20,7 @@ export default class UnitSelect extends PureComponent {
       unit: '',
     },
     readOnly: false,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/dataValueEditors/time/DetailsArea.js
+++ b/src/components/dataValueEditors/time/DetailsArea.js
@@ -23,7 +23,7 @@ export default class DetailsArea extends PureComponent {
     manualPrecision: PropTypes.number,
     onManualPrecisionToggle: PropTypes.func.isRequired,
     onManualPrecisionChange: PropTypes.func.isRequired,
-  }
+  };
 
   render() {
     const { spinner, error, preview,

--- a/src/components/dataValueEditors/time/TimeDataValueEditor.js
+++ b/src/components/dataValueEditors/time/TimeDataValueEditor.js
@@ -14,7 +14,7 @@ export default class TimeDataValueEditor extends PureComponent {
     datavalue: PropTypes.shape( Shapes.DataValue ),
     onDataValueChange: PropTypes.func.isRequired,
     readOnly: PropTypes.bool,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/dataValueEditors/wikibase-item/CreateNewButtonCell.js
+++ b/src/components/dataValueEditors/wikibase-item/CreateNewButtonCell.js
@@ -57,7 +57,7 @@ class PopupContent extends PureComponent {
   static propTypes = {
     onCreate: PropTypes.func.isRequired,
     instanceOf: PropTypes.arrayOf( PropTypes.string ),
-  }
+  };
 
   constructor() {
     super( ...arguments );
@@ -85,7 +85,7 @@ class EditorButtons extends PureComponent {
     onCreate: PropTypes.func.isRequired,
     editorTemplates: PropTypes.arrayOf( PropTypes.object ),
     typeIds: PropTypes.instanceOf( Set ),
-  }
+  };
 
   handleClickF( editorTemplate ) {
     return () => onNewElementClick( editorTemplate, editorTemplate.newEntityInstanceOf )

--- a/src/components/dataValueEditors/wikibase-item/WikibaseItemDataValueEditor.js
+++ b/src/components/dataValueEditors/wikibase-item/WikibaseItemDataValueEditor.js
@@ -19,11 +19,11 @@ export default class WikibaseItemDataValueEditor extends PureComponent {
     onDataValueChange: PropTypes.func.isRequired,
     propertyDescription: PropTypes.instanceOf( PropertyDescription ),
     readOnly: PropTypes.bool,
-  }
+  };
 
   static defaultProps = {
     readOnly: false,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/entityField/AutocompleteMode.js
+++ b/src/components/entityField/AutocompleteMode.js
@@ -19,11 +19,11 @@ class AutocompleteMode extends Component {
     onSelect: PropTypes.func.isRequired,
     readOnly: PropTypes.bool,
     testSuggestionsProvider: PropTypes.func,
-  }
+  };
 
   static defaultProps = {
     readOnly: false,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/entityField/SelectMode.js
+++ b/src/components/entityField/SelectMode.js
@@ -23,7 +23,7 @@ export default class SelectMode extends PureComponent {
     oneOf: PropTypes.arrayOf( PropTypes.string ).isRequired,
     onOtherSelect: PropTypes.func.isRequired,
     onSelect: PropTypes.func.isRequired,
-  }
+  };
 
   constructor() {
     super( ...arguments );
@@ -76,7 +76,7 @@ class SelectOption extends PureComponent {
     entityId: PropTypes.string.isRequired,
     description: PropTypes.string,
     label: PropTypes.string,
-  }
+  };
 
   render() {
     const { entityId, description, label } = this.props;

--- a/src/components/entityField/Suggestion.js
+++ b/src/components/entityField/Suggestion.js
@@ -9,7 +9,7 @@ export default class Suggestion extends PureComponent {
 
   static propTypes = {
     entityId: PropTypes.string.isRequired,
-  }
+  };
 
   render() {
     const { entityId } = this.props;

--- a/src/components/entityField/WikibaseItemInput.js
+++ b/src/components/entityField/WikibaseItemInput.js
@@ -13,7 +13,7 @@ export default class WikibaseItemInput extends PureComponent {
     onBlur: PropTypes.func,
     onChange: PropTypes.func.isRequired,
     onFocus: PropTypes.func,
-  }
+  };
 
   static getEtcProps( props ) {
     /* eslint no-unused-vars: 0 */

--- a/src/components/entityField/index.js
+++ b/src/components/entityField/index.js
@@ -13,11 +13,11 @@ export default class EntityField extends PureComponent {
     onChange: PropTypes.func.isRequired,
     readOnly: PropTypes.bool,
     value: PropTypes.string,
-  }
+  };
 
   static defaultProps = {
     readOnly: false,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/formbuilders/ErrorBoundary.js
+++ b/src/components/formbuilders/ErrorBoundary.js
@@ -6,11 +6,11 @@ export default class ErrorBoundary extends PureComponent {
   static propTypes = {
     children: PropTypes.node,
     description: PropTypes.string,
-  }
+  };
 
   state = {
     hasError: false,
-  }
+  };
 
   componentDidCatch( error, info ) {
     this.setState( { hasError: true } );

--- a/src/components/formbuilders/FieldsFilterByClaimExistence.js
+++ b/src/components/formbuilders/FieldsFilterByClaimExistence.js
@@ -16,7 +16,7 @@ class FieldsFilterByClaimExistence extends PureComponent {
     children: PropTypes.func.isRequired,
     claims: PropTypes.object.isRequired,
     fields: PropTypes.arrayOf( PropTypes.shape( FieldShape ) ).isRequired,
-  }
+  };
 
   render() {
     const { children, claims, fields } = this.props;
@@ -40,7 +40,7 @@ export default class Filter extends PureComponent {
     children: PropTypes.func.isRequired,
     enabled: PropTypes.bool.isRequired,
     fields: PropTypes.arrayOf( PropTypes.shape( FieldShape ) ).isRequired,
-  }
+  };
 
   render() {
     const { children, enabled, fields } = this.props;

--- a/src/components/formbuilders/FieldsFilterByTerm.js
+++ b/src/components/formbuilders/FieldsFilterByTerm.js
@@ -41,7 +41,7 @@ export default class FieldsFilterByTerm extends PureComponent {
     fields: PropTypes.arrayOf( PropTypes.shape( FieldShape ) ).isRequired,
     term: PropTypes.string.isRequired,
     propertyDescriptionCache: PropTypes.object.isRequired,
-  }
+  };
 
   render() {
     const { children, fields, propertyDescriptionCache, term } = this.props;

--- a/src/components/formbuilders/FieldsSortBy.js
+++ b/src/components/formbuilders/FieldsSortBy.js
@@ -35,7 +35,7 @@ export default class FieldsSortBy extends PureComponent {
     children: PropTypes.func.isRequired,
     fields: PropTypes.arrayOf( PropTypes.shape( FieldShape ) ).isRequired,
     sortBy: PropTypes.arrayOf( PropTypes.string ),
-  }
+  };
 
   render() {
     const { children, fields, propertyDescriptionCache, sortBy } = this.props;

--- a/src/components/formbuilders/FieldsetBuilder.js
+++ b/src/components/formbuilders/FieldsetBuilder.js
@@ -8,7 +8,7 @@ export default class FieldsetBuilder extends PureComponent {
 
   static propTypes = {
     fieldset: PropTypes.shape( FieldsetShape ).isRequired,
-  }
+  };
 
   render() {
     const { fieldset } = this.props;

--- a/src/components/formbuilders/SparqlPropertyGroup.js
+++ b/src/components/formbuilders/SparqlPropertyGroup.js
@@ -10,11 +10,11 @@ export default class SparqlPropertyGroup extends PureComponent {
   static propTypes = {
     sparql: PropTypes.string.isRequired,
     sortBy: PropTypes.string,
-  }
+  };
 
   static defaultProps = {
     sortBy: 'language, label',
-  }
+  };
 
   render() {
     const { sortBy, sparql } = this.props;

--- a/src/components/formbuilders/SpecialBuilder.js
+++ b/src/components/formbuilders/SpecialBuilder.js
@@ -7,7 +7,7 @@ export default class SpecialBuilder extends PureComponent {
 
   static propTypes = {
     type: PropTypes.string.isRequired,
-  }
+  };
 
   render() {
     const { type, ...etc } = this.props;

--- a/src/components/labelalike/AliasesEditor.js
+++ b/src/components/labelalike/AliasesEditor.js
@@ -23,12 +23,12 @@ export default class AliasesEditor extends PureComponent {
     onChange: PropTypes.func.isRequired,
     onChangeDraft: PropTypes.func.isRequired,
     values: PropTypes.arrayOf( PropTypes.string ),
-  }
+  };
 
   static defaultProps = {
     draft: '',
     values: EMPTY_ARRAY,
-  }
+  };
 
   render() {
     const { draft, values, onChange, onChangeDraft } = this.props;

--- a/src/components/labelalike/SingleLanguageEditor.js
+++ b/src/components/labelalike/SingleLanguageEditor.js
@@ -16,14 +16,14 @@ export default class SingleLanguageEditor extends PureComponent {
     onDescriptionChange: PropTypes.func.isRequired,
     onAliasesChange: PropTypes.func.isRequired,
     onDraftAliasChange: PropTypes.func.isRequired,
-  }
+  };
 
   static defaultProps = {
     label: '',
     description: '',
     aliases: [],
     draftAlias: '',
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/languages/LanguageAutocomplete.js
+++ b/src/components/languages/LanguageAutocomplete.js
@@ -12,12 +12,12 @@ export default class LanguageAutocomplete extends Component {
     provided: PropTypes.arrayOf( PropTypes.string ),
     onChange: PropTypes.func.isRequired,
     value: PropTypes.string,
-  }
+  };
 
   static defaultProps = {
     provided: [],
     value: DEFAULT_LANGUAGES[ 0 ],
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/qualifiers/ClaimQualifiersTable.js
+++ b/src/components/qualifiers/ClaimQualifiersTable.js
@@ -21,13 +21,13 @@ export default class ClaimQualifiersTable extends PureComponent {
     claim: PropTypes.shape( Claim ).isRequired,
     claimPropertyDescription: PropTypes.instanceOf( PropertyDescription ).isRequired,
     onClaimUpdate: PropTypes.func.isRequired,
-  }
+  };
 
   static defaultProps = {
     allowedQualifiers: [],
     defaultAddQuailifier: false,
     disabledQualifiers: [],
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/qualifiers/NewQualifierAutosuggest.js
+++ b/src/components/qualifiers/NewQualifierAutosuggest.js
@@ -13,7 +13,7 @@ export default class NewQualifierAutosuggest extends PureComponent {
 
     static propTypes = {
       onSelect: PropTypes.func.isRequired,
-    }
+    };
 
     constructor() {
       super( ...arguments );

--- a/src/components/qualifiers/NewQualifierSelect.js
+++ b/src/components/qualifiers/NewQualifierSelect.js
@@ -23,7 +23,7 @@ export default class NewQualifierSelect extends PureComponent {
     allowedQualifiers: PropTypes.arrayOf( PropTypes.string ).isRequired,
     alreadyPresent: PropTypes.arrayOf( PropTypes.string ).isRequired,
     onSelect: PropTypes.func.isRequired,
-  }
+  };
 
   constructor() {
     super( ...arguments );
@@ -74,7 +74,7 @@ class NewQualifierSelectOption extends PureComponent {
     propertyId: PropTypes.string.isRequired,
     description: PropTypes.string,
     label: PropTypes.string,
-  }
+  };
 
   render() {
     const { alreadyPresent, unsupported, propertyId, description, label } = this.props;

--- a/src/components/qualifiers/PropertySuggestion.js
+++ b/src/components/qualifiers/PropertySuggestion.js
@@ -8,7 +8,7 @@ export default class PropertySuggestion extends PureComponent {
 
   static propTypes = {
     propertyId: PropTypes.string.isRequired,
-  }
+  };
 
   render() {
     const { propertyId } = this.props;

--- a/src/components/qualifiers/SingleQualifierEditor.js
+++ b/src/components/qualifiers/SingleQualifierEditor.js
@@ -12,7 +12,7 @@ export default class SingleQualifierEditor extends PureComponent {
     claimPropertyDescription: PropTypes.instanceOf( PropertyDescription ).isRequired,
     onClaimUpdate: PropTypes.func.isRequired,
     qualifierPropertyDescription: PropTypes.instanceOf( PropertyDescription ).isRequired,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/references/ClaimReferenceEditor.js
+++ b/src/components/references/ClaimReferenceEditor.js
@@ -11,7 +11,7 @@ export default class ClaimReferenceEditor extends PureComponent {
   static propTypes = {
     onReferenceChange: PropTypes.func.isRequired,
     reference: PropTypes.object.isRequired,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/references/ClaimReferencesButtonCell.js
+++ b/src/components/references/ClaimReferencesButtonCell.js
@@ -12,7 +12,7 @@ export default class ClaimReferencesButtonCell extends PureComponent {
   static propTypes = {
     claim: PropTypes.shape( Claim ).isRequired,
     onClaimUpdate: PropTypes.func.isRequired,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/references/ClaimReferencesEditorContent.js
+++ b/src/components/references/ClaimReferencesEditorContent.js
@@ -18,7 +18,7 @@ export default class ClaimReferencesEditorContent extends PureComponent {
   static propTypes = {
     claim: PropTypes.shape( Claim ).isRequired,
     onClaimUpdate: PropTypes.func.isRequired,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/references/ClaimReferencesEditorDialog.js
+++ b/src/components/references/ClaimReferencesEditorDialog.js
@@ -12,7 +12,7 @@ export default class ClaimReferencesEditorDialog extends PureComponent {
     claim: PropTypes.shape( Claim ).isRequired,
     onClaimUpdate: PropTypes.func.isRequired,
     onCloseClick: PropTypes.func.isRequired,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/references/ReferencePropertySelect.js
+++ b/src/components/references/ReferencePropertySelect.js
@@ -11,7 +11,7 @@ export default class ReferencePropertySelect extends PureComponent {
   static propTypes = {
     alreadyPresent: PropTypes.arrayOf( PropTypes.string ).isRequired,
     onSelect: PropTypes.func.isRequired,
-  }
+  };
 
   constructor() {
     super( ...arguments );
@@ -76,7 +76,7 @@ class SelectOption extends PureComponent {
     propertyId: PropTypes.string.isRequired,
     description: PropTypes.string,
     label: PropTypes.string,
-  }
+  };
 
   render() {
     const { alreadyPresent, unsupported, propertyId, description, label } = this.props;

--- a/src/components/snaks/SnakTableRow.js
+++ b/src/components/snaks/SnakTableRow.js
@@ -15,12 +15,12 @@ export default class SnakTableRow extends PureComponent {
     propertyDescription: PropTypes.instanceOf( PropertyDescription ).isRequired,
     readOnly: PropTypes.bool,
     snak: PropTypes.object,
-  }
+  };
 
   static defaultProps = {
     displayLabel: true,
     readOnly: false,
-  }
+  };
 
   render() {
     const { firstCell, displayLabel, lastCell, onSnakChange, propertyDescription, snak, readOnly } = this.props;

--- a/src/components/snaks/SnaksArrayEditor.js
+++ b/src/components/snaks/SnaksArrayEditor.js
@@ -18,12 +18,12 @@ export default class SnaksArrayEditor extends PureComponent {
     readOnly: PropTypes.bool.isRequired,
     removeButtonLabel: PropTypes.string.isRequired,
     removeButtonConfirmMessage: PropTypes.string.isRequired,
-  }
+  };
 
   static defaultProps = {
     displayEmpty: false,
     displayLabels: true,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/components/snaks/SnaksMapEditor.js
+++ b/src/components/snaks/SnaksMapEditor.js
@@ -15,12 +15,12 @@ export default class SnaksMapEditor extends PureComponent {
     readOnly: PropTypes.bool,
     removeButtonLabel: PropTypes.string.isRequired,
     removeButtonConfirmMessageF: PropTypes.func.isRequired,
-  }
+  };
 
   static defaultProps = {
     ignorePropertyIds: [],
     readOnly: false,
-  }
+  };
 
   handleSnaksArrayUpdateF( propertyDescription ) {
     return snaksArray => {
@@ -69,7 +69,7 @@ class PropertyIsLoadingTBody extends PureComponent {
 
   static propTypes = {
     propertyId: PropTypes.string.isRequired,
-  }
+  };
 
   render() {
     const { propertyId } = this.props;

--- a/src/enhancements/family/FamilyMemberDataValueEditor.js
+++ b/src/enhancements/family/FamilyMemberDataValueEditor.js
@@ -33,7 +33,7 @@ class FamilyMemberDataValueEditor extends WikibaseItemDataValueEditor {
     newEntityGenderEntityId: PropTypes.oneOfType( PropTypes.func, PropTypes.string ).isRequired,
     propertyIdSelfInto: PropTypes.string.isRequired,
     propertiesMapping: PropTypes.object.isRequired,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/enhancements/importers/ImportDataDialog.js
+++ b/src/enhancements/importers/ImportDataDialog.js
@@ -19,7 +19,7 @@ class ImportDataDialog extends PureComponent {
   static propTypes = {
     dispatch: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/enhancements/population/PopulationLookupDialog.js
+++ b/src/enhancements/population/PopulationLookupDialog.js
@@ -12,7 +12,7 @@ export default class PopulationLookupDialog extends PureComponent {
   static propTypes = {
     onClaimAdd: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/enhancements/viaf/ViafLookupDialog.js
+++ b/src/enhancements/viaf/ViafLookupDialog.js
@@ -10,11 +10,11 @@ export default class ViafLookupDialog extends PureComponent {
   static propTypes = {
     defaultQuery: PropTypes.string,
     onSelect: PropTypes.func.isRequired,
-  }
+  };
 
   static defaultProps = {
     defaultQuery: '',
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/settings/EditorsLinks.js
+++ b/src/settings/EditorsLinks.js
@@ -11,7 +11,7 @@ export default class EditorLinks extends PureComponent {
 
   static propTypes = {
     editorTemplates: PropTypes.arrayOf( PropTypes.shape( EditorShape ) ),
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/settings/SettingsDialog.js
+++ b/src/settings/SettingsDialog.js
@@ -10,7 +10,7 @@ export default class SettingsDialog extends PureComponent {
 
   static propTypes = {
     editors: PropTypes.arrayOf( PropTypes.object ).isRequired,
-  }
+  };
 
   handleTrigger( editor ) {
     return () => {

--- a/src/sources/LruTab.js
+++ b/src/sources/LruTab.js
@@ -8,7 +8,7 @@ export default class LruTab extends PureComponent {
 
   static propTypes = {
     onInsert: PropTypes.func.isRequired,
-  }
+  };
 
   constructor() {
     super( ...arguments );

--- a/src/sources/NewSourceTab.js
+++ b/src/sources/NewSourceTab.js
@@ -11,7 +11,7 @@ export default class NewSourceTab extends PureComponent {
 
   static propTypes = {
     onInsert: PropTypes.func.isRequired,
-  }
+  };
 
   handleClickF( editorDescription, classId ) {
     return () => {

--- a/src/sources/SourceItem.js
+++ b/src/sources/SourceItem.js
@@ -7,7 +7,7 @@ export default class SourceItem extends PureComponent {
 
   static propTypes = {
     entityId: PropTypes.string.isRequired,
-  }
+  };
 
   render() {
     const { entityId, ...etc } = this.props;

--- a/src/sources/SourceLookupTab.js
+++ b/src/sources/SourceLookupTab.js
@@ -11,7 +11,7 @@ export default class SourceLookupTab extends PureComponent {
 
   static propTypes = {
     onInsert: PropTypes.func.isRequired,
-  }
+  };
 
   constructor() {
     super( ...arguments );


### PR DESCRIPTION
`static foo = {...}`  is a statement, so it should end with a semicolon.
Plus it seems to break the ES rules

(originally it was part of #28, but there were too many so separated)