### PR TITLE
Eslint and minor cleanup of Gadgets code

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,9 +27,8 @@ module.exports = {
     "mw": true,
     "require": true,
 
-    // for test:
-    "describe": true,
-    "it": true,
+    /* root dir only, disabled in src/ */
+    "process": true,
   },
   "plugins": [ "promise" ],
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -195,4 +195,4 @@ module.exports = {
       }
     }
   }
-}
+};

--- a/deploy-to-wikipedia.js
+++ b/deploy-to-wikipedia.js
@@ -93,7 +93,6 @@ const loginPromise = loginTokenPromise.then( logintoken => {
         console.log( login );
         throw new Error( 'Unable to login as ' + lgname );
       }
-      return;
     } );
 } );
 
@@ -106,7 +105,7 @@ const csrfTokenPromise = loginPromise.then( () => {
     .then( json => json.query.tokens.csrftoken );
 } );
 
-const editPromise = csrfTokenPromise.then( csrftoken => {
+csrfTokenPromise.then( csrftoken => {
   const articleName = 'User:Vlsergey/wef.js';
   console.log( 'Uploading app.bundle.js as ' + articleName + '...' );
 

--- a/gadget/.eslintrc.js
+++ b/gadget/.eslintrc.js
@@ -1,0 +1,30 @@
+'use strict';
+
+module.exports = {
+  "globals": {
+    "addOnloadHook": true,
+    "ISBN": true,
+    "jsMsg": true,
+    "mediaWiki": true,
+    "WEF_Editor": true,
+    "wef_editors_registry": true,
+    "wef_LabelsCache": true,
+    "WEF_LatestUsedSources": true,
+    "WEF_Utils": true,
+    "wikibase": true,
+  },
+  "rules": {
+    "comma-dangle": "off",
+    "indent": ["warn", "tab", { "ArrayExpression": 2 }],
+    "no-redeclare": "off",
+    "no-var": "off",
+    "object-shorthand": "off",
+    "operator-linebreak": "off",
+    "prefer-arrow-callback": "off",
+    "prefer-destructuring": "off",
+    "prefer-spread": "off",
+    "quote-props": "off",
+    "quotes": "off",
+    "strict": "off",
+  },
+};

--- a/gadget/Gadget-isbnjs.js
+++ b/gadget/Gadget-isbnjs.js
@@ -831,8 +831,9 @@ window.ISBN._isbn.prototype = {
 	_merge: function( lobj, robj ) {
 		if ( !lobj || !robj )
 			return null;
-		for ( var key in robj )
-			lobj[key] = robj[key];
+		Object.keys( robj ).forEach( function( key ) {
+			lobj[ key ] = robj[ key ];
+		} );
 		return lobj;
 	},
 
@@ -842,7 +843,7 @@ window.ISBN._isbn.prototype = {
 			isValid: true,
 			isIsbn10: true,
 			isIsbn13: false
-		}, this._split( val ) ) ) : val.length == 13 && val.match( /^(\d+)-(\d+)-(\d+)-([\dX])$/ ) ? this._fill( {
+		}, this._split( val ) ) ) : val.length === 13 && val.match( /^(\d+)-(\d+)-(\d+)-([\dX])$/ ) ? this._fill( {
 			source: val,
 			isValid: true,
 			isIsbn10: true,
@@ -857,7 +858,7 @@ window.ISBN._isbn.prototype = {
 			isIsbn10: false,
 			isIsbn13: true,
 			prefix: RegExp.$1
-		}, this._split( RegExp.$2 ) ) ) : val.length == 17 && val.match( /^(978|979)-(\d+)-(\d+)-(\d+)-([\dX])$/ ) ? this._fill( {
+		}, this._split( RegExp.$2 ) ) ) : val.length === 17 && val.match( /^(978|979)-(\d+)-(\d+)-(\d+)-([\dX])$/ ) ? this._fill( {
 			source: val,
 			isValid: true,
 			isIsbn10: false,
@@ -875,9 +876,11 @@ window.ISBN._isbn.prototype = {
 	},
 
 	_split: function( isbn ) {
-		return ( !isbn ? null : isbn.length == 13 ? this._merge( this._split( isbn.substr( 3 ) ), {
-			prefix: isbn.substr( 0, 3 )
-		} ) : isbn.length == 10 ? this._splitToObject( isbn ) : null );
+		return !isbn
+			? null
+			: isbn.length === 13
+				? this._merge( this._split( isbn.substr( 3 ) ), { prefix: isbn.substr( 0, 3 ) } )
+				: isbn.length === 10 ? this._splitToObject( isbn ) : null;
 	},
 
 	_splitToArray: function( isbn10 ) {
@@ -886,8 +889,8 @@ window.ISBN._isbn.prototype = {
 			return null;
 
 		for ( var key, i = 0, m = rec.record.ranges.length; i < m; ++i ) {
-			key = rec.rest.substr( 0, rec.record.ranges[i][0].length );
-			if ( rec.record.ranges[i][0] <= key && rec.record.ranges[i][1] >= key ) {
+			key = rec.rest.substr( 0, rec.record.ranges[ i ][ 0 ].length );
+			if ( rec.record.ranges[ i ][ 0 ] <= key && rec.record.ranges[ i ][ 1 ] >= key ) {
 				var rest = rec.rest.substr( key.length );
 				return [ rec.group, key, rest.substr( 0, rest.length - 1 ), rest.charAt( rest.length - 1 ) ];
 			}
@@ -897,13 +900,13 @@ window.ISBN._isbn.prototype = {
 
 	_splitToObject: function( isbn10 ) {
 		var a = this._splitToArray( isbn10 );
-		if ( !a || a.length != 4 )
+		if ( !a || a.length !== 4 )
 			return null;
 		return {
-			group: a[0],
-			publisher: a[1],
-			article: a[2],
-			check: a[3]
+			group: a[ 0 ],
+			publisher: a[ 1 ],
+			article: a[ 2 ],
+			check: a[ 3 ]
 		};
 	},
 
@@ -911,7 +914,7 @@ window.ISBN._isbn.prototype = {
 		if ( !codes )
 			return null;
 
-		var rec = this.groups[codes.group];
+		var rec = this.groups[ codes.group ];
 		if ( !rec )
 			return null;
 
@@ -933,7 +936,7 @@ window.ISBN._isbn.prototype = {
 			groupname: rec.name
 		} );
 
-		if ( prefix == '978' ) {
+		if ( prefix === '978' ) {
 			var parts10 = [ codes.group, codes.publisher, codes.article, ck10 ];
 			this._merge( codes, {
 				isbn10: parts10.join( '' ),
@@ -945,14 +948,15 @@ window.ISBN._isbn.prototype = {
 	},
 
 	_getGroupRecord: function( isbn10 ) {
-		for ( var key in this.groups ) {
+		var groups = this.groups;
+		Object.keys( groups ).forEach( function( key ) {
 			if ( isbn10.match( '^' + key + '(.+)' ) )
 				return {
 					group: key,
-					record: this.groups[key],
+					record: groups[ key ],
 					rest: RegExp.$1
 				};
-		}
+		} );
 		return null;
 	},
 
@@ -962,7 +966,7 @@ window.ISBN._isbn.prototype = {
 			for ( var n = 0; n < 9; ++n )
 				c += ( 10 - n ) * isbn.charAt( n );
 			c = ( 11 - c % 11 ) % 11;
-			return c == 10 ? 'X' : String( c );
+			return c === 10 ? 'X' : String( c );
 
 		} else if ( isbn.match( /(?:978|979)\d{9}[\dX]?/ ) ) {
 			var c = 0;

--- a/gadget/Gadget-wefbook.js
+++ b/gadget/Gadget-wefbook.js
@@ -1,171 +1,171 @@
-var wef_SourceBookEditor_html = "<div class=\'wef_sourceBookEditor_dialog\'>\r\n" + 
-		"	<div class=\'wef_tabs\'>\r\n" + 
-		"		<ul>\r\n" + 
-		"			<li><a href=\'#wef_sourceBookEditor_tab_general\' class=\'wef_editor_tab_anchor wef_i18n_text\'>groupGeneral</a></li>\r\n" + 
-		"			<li><a href=\'#wef_sourceBookEditor_tab_codes\' class=\'wef_editor_tab_anchor wef_i18n_label\'>Q5962346</a></li>\r\n" + 
-		"		</ul>\r\n" + 
-		"		<div id=\'wef_sourceBookEditor_tab_general\' class=\'wef_editor_tab\'>\r\n" + 
-		"			<div class=\"wef_labels_editor\"></div>\r\n" + 
-		"			<fieldset class=\'wef_fieldset\'>\r\n" + 
-		"				<table class=\'wef_table\'>\r\n" + 
-		"					<!-- instance of -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P31\' data-datatype=\'wikibase-item\' />\r\n" + 
-		"				</table>\r\n" + 
-		"				<table class=\'wef_table\'>\r\n" + 
-		"					<!-- title -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P1476\' data-datatype=\'monolingualtext\' />\r\n" + 
-		"					<!-- subtitle -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P1680\' data-datatype=\'monolingualtext\' />\r\n" + 
-		"					<!--  ISO 4 abbreviation -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P1160\' data-datatype=\'string\' />\r\n" + 
-		"					<!-- language -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P407\' data-datatype=\'wikibase-item\' />\r\n" + 
-		"					<!-- date of foundation or creation -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P571\' data-datatype=\'time\' />\r\n" + 
-		"					<!--  edition number  -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P393\' data-datatype=\'string\' />\r\n" + 
-		"				</table>\r\n" + 
-		"			</fieldset>\r\n" + 
-		"			<fieldset class=\'wef_fieldset\'>\r\n" + 
-		"				<table class=\'wef_table\'>\r\n" + 
-		"					<!-- author -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P50\' data-datatype=\'wikibase-item\'>\r\n" + 
-		"						<!-- stated as -->\r\n" + 
-		"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"					<!-- contributor  -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P767\' data-datatype=\'wikibase-item\'>\r\n" + 
-		"						<!-- stated as -->\r\n" + 
-		"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"					<!-- editor -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P98\' data-datatype=\'wikibase-item\'>\r\n" + 
-		"						<!-- stated as -->\r\n" + 
-		"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"					<!-- illustrator -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P110\' data-datatype=\'wikibase-item\'>\r\n" + 
-		"						<!-- stated as -->\r\n" + 
-		"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"					<!-- translator -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P655\' data-datatype=\'wikibase-item\'>\r\n" + 
-		"						<!-- stated as -->\r\n" + 
-		"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"				</table>\r\n" + 
-		"			</fieldset>\r\n" + 
-		"			<fieldset class=\'wef_fieldset\'>\r\n" + 
-		"				<table class=\'wef_table\'>\r\n" + 
-		"					<!-- place of publication -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P291\' data-datatype=\'wikibase-item\'>\r\n" + 
-		"						<!-- stated as -->\r\n" + 
-		"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"					<!-- publisher -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P123\' data-datatype=\'wikibase-item\'>\r\n" + 
-		"						<!-- stated as -->\r\n" + 
-		"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"					<!-- date of publication -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P577\' data-datatype=\'time\' />\r\n" + 
-		"					<!-- printed by -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P872\' data-datatype=\'wikibase-item\'>\r\n" + 
-		"						<!-- stated as -->\r\n" + 
-		"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"				</table>\r\n" + 
-		"			</fieldset>\r\n" + 
-		"			<fieldset class=\'wef_fieldset\'>\r\n" + 
-		"				<table class=\'wef_table\'>\r\n" + 
-		"					<!-- part of -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P361\' data-datatype=\'wikibase-item\'>\r\n" + 
-		"						<!-- stated as -->\r\n" + 
-		"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" + 
-		"						<!-- volume -->\r\n" + 
-		"						<tr class=\'wef_claim_editors\' data-code=\'P478\' data-datatype=\'string\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"					<!-- volume -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P478\' data-datatype=\'string\' />\r\n" + 
-		"					<!-- issue -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P433\' data-datatype=\'string\' />\r\n" + 
-		"					<!-- total pages -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P1104\' data-datatype=\'quantity\' />\r\n" + 
-		"				</table>\r\n" + 
-		"			</fieldset>\r\n" + 
-		"			<fieldset class=\'wef_fieldset\'>\r\n" + 
-		"				<table class=\'wef_table \'>\r\n" + 
-		"					<!-- URL -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P953\' data-datatype=\'url\'>\r\n" + 
-		"						<!-- check date -->\r\n" + 
-		"						<tr class=\'wef_claim_editors\' data-code=\'P813\' data-datatype=\'time\' />\r\n" + 
-		"						<!-- archive URL -->\r\n" + 
-		"						<tr class=\'wef_claim_editors\' data-code=\'P1065\' data-datatype=\'url\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"					<!-- scan file -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P996\' data-datatype=\'commonsMedia\' />\r\n" + 
-		"					<!-- Wikisource index page -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P1957\' data-datatype=\'url\' />\r\n" + 
-		"				</table>\r\n" + 
-		"			</fieldset>\r\n" + 
-		"		</div>\r\n" + 
-		"		<div id=\'wef_sourceBookEditor_tab_codes\' class=\'wef_editor_tab\'>\r\n" + 
-		"			<fieldset class=\'wef_fieldset\'>\r\n" + 
-		"				<table class=\'wef_table\'>\r\n" + 
-		"					<!-- DOI -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P356\' data-datatype=\'string\' data-template=\'https://dx.doi.org/$1\' />\r\n" + 
-		"					<!-- ISBN 10 -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P957\' data-datatype=\'string\' />\r\n" + 
-		"					<!-- ISBN 13 -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P212\' data-datatype=\'string\' />\r\n" + 
-		"					<!-- ISSN -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P236\' data-datatype=\'string\' />\r\n" + 
-		"				</table>\r\n" + 
-		"			</fieldset>\r\n" + 
-		"			<fieldset class=\'wef_fieldset\'>\r\n" + 
-		"				<table class=\'wef_table\'>\r\n" + 
-		"					<!-- OCLC control number -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P243\' data-datatype=\'string\'\r\n" + 
-		"						data-template=\'https://www.worldcat.org/oclc/$1?lang=\' />\r\n" + 
-		"					<!-- Open Library identifier -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P648\' data-datatype=\'string\'\r\n" + 
-		"						data-template=\'https://openlibrary.org/works/$1\' />\r\n" + 
-		"					<!-- Google Books identifier -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P675\' data-datatype=\'string\'\r\n" + 
-		"						data-template=\'http://books.google.com/books?id=$1\' />\r\n" + 
-		"					<!-- Internet Archive identifier -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P724\' data-datatype=\'string\'\r\n" + 
-		"						data-template=\'https://archive.org/details/$1\' />\r\n" + 
-		"				</table>\r\n" + 
-		"			</fieldset>\r\n" + 
-		"			<fieldset class=\'wef_fieldset\'>\r\n" + 
-		"				<table class=\'wef_table\'>\r\n" + 
-		"					<!-- BN (Argentine) editions -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P1143\' data-datatype=\'string\' data-flag=\'ar\'\r\n" + 
-		"						data-template=\'http://catalogo.bn.gov.ar/F/?func=find-b&request=$1&find_code=SYS\' />\r\n" + 
-		"					<!-- SWB editions -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P1044\' data-datatype=\'string\' data-flag=\'de\'\r\n" + 
-		"						data-template=\'http://swb.bsz-bw.de/DB=2.1/PPNSET?PPN=$1&INDEXSET=1\' />\r\n" + 
-		"					<!-- DNB editions -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P1292\' data-datatype=\'string\' data-flag=\'de\'\r\n" + 
-		"						data-template=\'http://d-nb.info/$1\' />\r\n" + 
-		"					<!-- SUDOC editions -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P1025\' data-datatype=\'string\' data-flag=\'fr\'\r\n" + 
-		"						data-template=\'http://www.sudoc.fr/$1\' />\r\n" + 
-		"					<!-- EUL editions -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P1084\' data-datatype=\'string\' data-flag=\'eg\'\r\n" + 
-		"						data-template=\'http://srv3.eulc.edu.eg/eulc_v5/libraries/Start.aspx?fn=ApplySearch&BibID=$1\' />\r\n" + 
-		"					<!-- RSL scanned book\'s identifier -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P1815\' data-datatype=\'string\' data-flag=\'ru\'\r\n" + 
-		"						data-template=\'http://dlib.rsl.ru/viewer/$1\' />\r\n" + 
-		"					<!-- LIBRIS editions -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P1182\' data-datatype=\'string\' data-flag=\'se\'\r\n" + 
-		"						data-template=\'http://libris.kb.se/bib/$1\' />\r\n" + 
-		"				</table>\r\n" + 
-		"			</fieldset>\r\n" + 
-		"		</div>\r\n" + 
-		"	</div>\r\n" + 
-		"</div>";
+var wef_SourceBookEditor_html = "<div class=\'wef_sourceBookEditor_dialog\'>\r\n" +
+"	<div class=\'wef_tabs\'>\r\n" +
+"		<ul>\r\n" +
+"			<li><a href=\'#wef_sourceBookEditor_tab_general\' class=\'wef_editor_tab_anchor wef_i18n_text\'>groupGeneral</a></li>\r\n" +
+"			<li><a href=\'#wef_sourceBookEditor_tab_codes\' class=\'wef_editor_tab_anchor wef_i18n_label\'>Q5962346</a></li>\r\n" +
+"		</ul>\r\n" +
+"		<div id=\'wef_sourceBookEditor_tab_general\' class=\'wef_editor_tab\'>\r\n" +
+"			<div class=\"wef_labels_editor\"></div>\r\n" +
+"			<fieldset class=\'wef_fieldset\'>\r\n" +
+"				<table class=\'wef_table\'>\r\n" +
+"					<!-- instance of -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P31\' data-datatype=\'wikibase-item\' />\r\n" +
+"				</table>\r\n" +
+"				<table class=\'wef_table\'>\r\n" +
+"					<!-- title -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P1476\' data-datatype=\'monolingualtext\' />\r\n" +
+"					<!-- subtitle -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P1680\' data-datatype=\'monolingualtext\' />\r\n" +
+"					<!--  ISO 4 abbreviation -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P1160\' data-datatype=\'string\' />\r\n" +
+"					<!-- language -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P407\' data-datatype=\'wikibase-item\' />\r\n" +
+"					<!-- date of foundation or creation -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P571\' data-datatype=\'time\' />\r\n" +
+"					<!--  edition number  -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P393\' data-datatype=\'string\' />\r\n" +
+"				</table>\r\n" +
+"			</fieldset>\r\n" +
+"			<fieldset class=\'wef_fieldset\'>\r\n" +
+"				<table class=\'wef_table\'>\r\n" +
+"					<!-- author -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P50\' data-datatype=\'wikibase-item\'>\r\n" +
+"						<!-- stated as -->\r\n" +
+"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" +
+"					</tbody>\r\n" +
+"					<!-- contributor  -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P767\' data-datatype=\'wikibase-item\'>\r\n" +
+"						<!-- stated as -->\r\n" +
+"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" +
+"					</tbody>\r\n" +
+"					<!-- editor -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P98\' data-datatype=\'wikibase-item\'>\r\n" +
+"						<!-- stated as -->\r\n" +
+"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" +
+"					</tbody>\r\n" +
+"					<!-- illustrator -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P110\' data-datatype=\'wikibase-item\'>\r\n" +
+"						<!-- stated as -->\r\n" +
+"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" +
+"					</tbody>\r\n" +
+"					<!-- translator -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P655\' data-datatype=\'wikibase-item\'>\r\n" +
+"						<!-- stated as -->\r\n" +
+"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" +
+"					</tbody>\r\n" +
+"				</table>\r\n" +
+"			</fieldset>\r\n" +
+"			<fieldset class=\'wef_fieldset\'>\r\n" +
+"				<table class=\'wef_table\'>\r\n" +
+"					<!-- place of publication -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P291\' data-datatype=\'wikibase-item\'>\r\n" +
+"						<!-- stated as -->\r\n" +
+"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" +
+"					</tbody>\r\n" +
+"					<!-- publisher -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P123\' data-datatype=\'wikibase-item\'>\r\n" +
+"						<!-- stated as -->\r\n" +
+"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" +
+"					</tbody>\r\n" +
+"					<!-- date of publication -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P577\' data-datatype=\'time\' />\r\n" +
+"					<!-- printed by -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P872\' data-datatype=\'wikibase-item\'>\r\n" +
+"						<!-- stated as -->\r\n" +
+"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" +
+"					</tbody>\r\n" +
+"				</table>\r\n" +
+"			</fieldset>\r\n" +
+"			<fieldset class=\'wef_fieldset\'>\r\n" +
+"				<table class=\'wef_table\'>\r\n" +
+"					<!-- part of -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P361\' data-datatype=\'wikibase-item\'>\r\n" +
+"						<!-- stated as -->\r\n" +
+"						<tr class=\'wef_claim_editors\' data-code=\'P1932\' data-datatype=\'string\' />\r\n" +
+"						<!-- volume -->\r\n" +
+"						<tr class=\'wef_claim_editors\' data-code=\'P478\' data-datatype=\'string\' />\r\n" +
+"					</tbody>\r\n" +
+"					<!-- volume -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P478\' data-datatype=\'string\' />\r\n" +
+"					<!-- issue -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P433\' data-datatype=\'string\' />\r\n" +
+"					<!-- total pages -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P1104\' data-datatype=\'quantity\' />\r\n" +
+"				</table>\r\n" +
+"			</fieldset>\r\n" +
+"			<fieldset class=\'wef_fieldset\'>\r\n" +
+"				<table class=\'wef_table \'>\r\n" +
+"					<!-- URL -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P953\' data-datatype=\'url\'>\r\n" +
+"						<!-- check date -->\r\n" +
+"						<tr class=\'wef_claim_editors\' data-code=\'P813\' data-datatype=\'time\' />\r\n" +
+"						<!-- archive URL -->\r\n" +
+"						<tr class=\'wef_claim_editors\' data-code=\'P1065\' data-datatype=\'url\' />\r\n" +
+"					</tbody>\r\n" +
+"					<!-- scan file -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P996\' data-datatype=\'commonsMedia\' />\r\n" +
+"					<!-- Wikisource index page -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P1957\' data-datatype=\'url\' />\r\n" +
+"				</table>\r\n" +
+"			</fieldset>\r\n" +
+"		</div>\r\n" +
+"		<div id=\'wef_sourceBookEditor_tab_codes\' class=\'wef_editor_tab\'>\r\n" +
+"			<fieldset class=\'wef_fieldset\'>\r\n" +
+"				<table class=\'wef_table\'>\r\n" +
+"					<!-- DOI -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P356\' data-datatype=\'string\' data-template=\'https://dx.doi.org/$1\' />\r\n" +
+"					<!-- ISBN 10 -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P957\' data-datatype=\'string\' />\r\n" +
+"					<!-- ISBN 13 -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P212\' data-datatype=\'string\' />\r\n" +
+"					<!-- ISSN -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P236\' data-datatype=\'string\' />\r\n" +
+"				</table>\r\n" +
+"			</fieldset>\r\n" +
+"			<fieldset class=\'wef_fieldset\'>\r\n" +
+"				<table class=\'wef_table\'>\r\n" +
+"					<!-- OCLC control number -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P243\' data-datatype=\'string\'\r\n" +
+"						data-template=\'https://www.worldcat.org/oclc/$1?lang=\' />\r\n" +
+"					<!-- Open Library identifier -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P648\' data-datatype=\'string\'\r\n" +
+"						data-template=\'https://openlibrary.org/works/$1\' />\r\n" +
+"					<!-- Google Books identifier -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P675\' data-datatype=\'string\'\r\n" +
+"						data-template=\'http://books.google.com/books?id=$1\' />\r\n" +
+"					<!-- Internet Archive identifier -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P724\' data-datatype=\'string\'\r\n" +
+"						data-template=\'https://archive.org/details/$1\' />\r\n" +
+"				</table>\r\n" +
+"			</fieldset>\r\n" +
+"			<fieldset class=\'wef_fieldset\'>\r\n" +
+"				<table class=\'wef_table\'>\r\n" +
+"					<!-- BN (Argentine) editions -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P1143\' data-datatype=\'string\' data-flag=\'ar\'\r\n" +
+"						data-template=\'http://catalogo.bn.gov.ar/F/?func=find-b&request=$1&find_code=SYS\' />\r\n" +
+"					<!-- SWB editions -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P1044\' data-datatype=\'string\' data-flag=\'de\'\r\n" +
+"						data-template=\'http://swb.bsz-bw.de/DB=2.1/PPNSET?PPN=$1&INDEXSET=1\' />\r\n" +
+"					<!-- DNB editions -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P1292\' data-datatype=\'string\' data-flag=\'de\'\r\n" +
+"						data-template=\'http://d-nb.info/$1\' />\r\n" +
+"					<!-- SUDOC editions -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P1025\' data-datatype=\'string\' data-flag=\'fr\'\r\n" +
+"						data-template=\'http://www.sudoc.fr/$1\' />\r\n" +
+"					<!-- EUL editions -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P1084\' data-datatype=\'string\' data-flag=\'eg\'\r\n" +
+"						data-template=\'http://srv3.eulc.edu.eg/eulc_v5/libraries/Start.aspx?fn=ApplySearch&BibID=$1\' />\r\n" +
+"					<!-- RSL scanned book\'s identifier -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P1815\' data-datatype=\'string\' data-flag=\'ru\'\r\n" +
+"						data-template=\'http://dlib.rsl.ru/viewer/$1\' />\r\n" +
+"					<!-- LIBRIS editions -->\r\n" +
+"					<tbody class=\'wef_claim_editors\' data-code=\'P1182\' data-datatype=\'string\' data-flag=\'se\'\r\n" +
+"						data-template=\'http://libris.kb.se/bib/$1\' />\r\n" +
+"				</table>\r\n" +
+"			</fieldset>\r\n" +
+"		</div>\r\n" +
+"	</div>\r\n" +
+"</div>";
 
 window.wef_SourceBookEditor_i18n_en = {
 	dialogTitle: 'Book — WE-Framework',

--- a/gadget/Gadget-wefdocument.js
+++ b/gadget/Gadget-wefdocument.js
@@ -1,60 +1,60 @@
 /**
  * This JavaScript is a implementation of JavaScript Gadget to edit normative
  * document information on Wikidata. This script is based on WE-Framework.
- * 
+ *
  * @see https://github.com/vlsergey/WE-Framework
  * @author vlsergey
  */
-var wef_WorkEditor_html = "<div class=\'wef_documentEditor_dialog\'>\r\n" + 
-		"    <div class=\'wef_tabs\'>\r\n" + 
-		"        <ul>\r\n" + 
-		"            <li><a href=\'#wef_documentEditor_tab_general\' class=\'wef_editor_tab_anchor wef_i18n_text\'>groupGeneral</a></li>\r\n" + 
-		"            <li><a href=\'#wef_documentEditor_tab_editions\' class=\'wef_editor_tab_anchor wef_i18n_label\'>P747</a></li>\r\n" + 
-		"        </ul>\r\n" + 
-		"        <div id=\'wef_documentEditor_tab_general\' class=\'wef_editor_tab\'>\r\n" + 
-		"            <div class=\"wef_labels_editor\"></div>\r\n" + 
-		"            <fieldset class=\'wef_fieldset\'>\r\n" + 
-		"                <table class=\'wef_table\'>\r\n" + 
-		"                    <!-- instance of -->\r\n" + 
-		"                    <tbody class=\'wef_claim_editors\' data-code=\'P31\' data-datatype=\'wikibase-item\' />\r\n" + 
-		"                    <!-- number -->\r\n" + 
-		"                    <tbody class=\'wef_claim_editors\' data-code=\'P1545\' data-datatype=\'string\' />\r\n" + 
-		"                    <!-- date of foundation or creation -->\r\n" + 
-		"                    <tbody class=\'wef_claim_editors\' data-code=\'P571\' data-datatype=\'time\' />\r\n" + 
-		"                    <!-- title -->\r\n" + 
-		"                    <tbody class=\'wef_claim_editors\' data-code=\'P1476\' data-datatype=\'monolingualtext\' />\r\n" + 
-		"                    <!-- subtitle -->\r\n" + 
-		"                    <tbody class=\'wef_claim_editors\' data-code=\'P1680\' data-datatype=\'monolingualtext\' />\r\n" + 
-		"                </table>\r\n" + 
-		"            </fieldset>\r\n" + 
-		"\r\n" + 
-		"            <fieldset class=\'wef_fieldset\'>\r\n" + 
-		"                <table class=\'wef_table\'>\r\n" + 
-		"                    <!-- original language -->\r\n" + 
-		"                    <tbody class=\'wef_claim_editors\' data-code=\'P364\' data-datatype=\'wikibase-item\' />\r\n" + 
-		"                    <!-- date of publication -->\r\n" + 
-		"                    <tbody class=\'wef_claim_editors\' data-code=\'P577\' data-datatype=\'time\' />\r\n" + 
-		"                </table>\r\n" + 
-		"            </fieldset>\r\n" + 
-		"\r\n" + 
-		"            <table class=\'wef_table\'>\r\n" + 
-		"                <!-- image -->\r\n" + 
-		"                <tbody class=\'wef_claim_editors\' data-code=\'P18\' data-datatype=\'commonsMedia\' />\r\n" + 
-		"            </table>\r\n" + 
-		"        </div>\r\n" + 
-		"        <div id=\'wef_documentEditor_tab_editions\' class=\'wef_editor_tab\'>\r\n" + 
-		"            <fieldset class=\'wef_fieldset wef_single_property_fieldset\'>\r\n" + 
-		"                <legend class=\'wef_i18n_label\'>P747</legend>\r\n" + 
-		"                <table class=\'wef_table\'>\r\n" + 
-		"                    <!-- edition -->\r\n" + 
-		"                    <tbody class=\'wef_claim_editors\' data-code=\'P747\' data-datatype=\'wikibase-item\'>\r\n" + 
-		"                    </tbody>\r\n" + 
-		"                </table>\r\n" + 
-		"            </fieldset>\r\n" + 
-		"        </div>\r\n" + 
-		"    </div>\r\n" + 
-		"\r\n" + 
-		"</div>";
+var wef_WorkEditor_html = "<div class=\'wef_documentEditor_dialog\'>\r\n" +
+"    <div class=\'wef_tabs\'>\r\n" +
+"        <ul>\r\n" +
+"            <li><a href=\'#wef_documentEditor_tab_general\' class=\'wef_editor_tab_anchor wef_i18n_text\'>groupGeneral</a></li>\r\n" +
+"            <li><a href=\'#wef_documentEditor_tab_editions\' class=\'wef_editor_tab_anchor wef_i18n_label\'>P747</a></li>\r\n" +
+"        </ul>\r\n" +
+"        <div id=\'wef_documentEditor_tab_general\' class=\'wef_editor_tab\'>\r\n" +
+"            <div class=\"wef_labels_editor\"></div>\r\n" +
+"            <fieldset class=\'wef_fieldset\'>\r\n" +
+"                <table class=\'wef_table\'>\r\n" +
+"                    <!-- instance of -->\r\n" +
+"                    <tbody class=\'wef_claim_editors\' data-code=\'P31\' data-datatype=\'wikibase-item\' />\r\n" +
+"                    <!-- number -->\r\n" +
+"                    <tbody class=\'wef_claim_editors\' data-code=\'P1545\' data-datatype=\'string\' />\r\n" +
+"                    <!-- date of foundation or creation -->\r\n" +
+"                    <tbody class=\'wef_claim_editors\' data-code=\'P571\' data-datatype=\'time\' />\r\n" +
+"                    <!-- title -->\r\n" +
+"                    <tbody class=\'wef_claim_editors\' data-code=\'P1476\' data-datatype=\'monolingualtext\' />\r\n" +
+"                    <!-- subtitle -->\r\n" +
+"                    <tbody class=\'wef_claim_editors\' data-code=\'P1680\' data-datatype=\'monolingualtext\' />\r\n" +
+"                </table>\r\n" +
+"            </fieldset>\r\n" +
+"\r\n" +
+"            <fieldset class=\'wef_fieldset\'>\r\n" +
+"                <table class=\'wef_table\'>\r\n" +
+"                    <!-- original language -->\r\n" +
+"                    <tbody class=\'wef_claim_editors\' data-code=\'P364\' data-datatype=\'wikibase-item\' />\r\n" +
+"                    <!-- date of publication -->\r\n" +
+"                    <tbody class=\'wef_claim_editors\' data-code=\'P577\' data-datatype=\'time\' />\r\n" +
+"                </table>\r\n" +
+"            </fieldset>\r\n" +
+"\r\n" +
+"            <table class=\'wef_table\'>\r\n" +
+"                <!-- image -->\r\n" +
+"                <tbody class=\'wef_claim_editors\' data-code=\'P18\' data-datatype=\'commonsMedia\' />\r\n" +
+"            </table>\r\n" +
+"        </div>\r\n" +
+"        <div id=\'wef_documentEditor_tab_editions\' class=\'wef_editor_tab\'>\r\n" +
+"            <fieldset class=\'wef_fieldset wef_single_property_fieldset\'>\r\n" +
+"                <legend class=\'wef_i18n_label\'>P747</legend>\r\n" +
+"                <table class=\'wef_table\'>\r\n" +
+"                    <!-- edition -->\r\n" +
+"                    <tbody class=\'wef_claim_editors\' data-code=\'P747\' data-datatype=\'wikibase-item\'>\r\n" +
+"                    </tbody>\r\n" +
+"                </table>\r\n" +
+"            </fieldset>\r\n" +
+"        </div>\r\n" +
+"    </div>\r\n" +
+"\r\n" +
+"</div>";
 
 window.wef_WorkEditor_i18n_en = {
 	dialogTitle: 'Document — WE-Framework',

--- a/gadget/Gadget-weffreeze.js
+++ b/gadget/Gadget-weffreeze.js
@@ -44,7 +44,7 @@
 	/* Some utils functions */
 
 	function getFirstObjectValue( obj ) {
-		return obj[Object.keys( obj )[0]];
+		return obj[ Object.keys( obj )[ 0 ] ];
 	}
 
 	function getWikidataApiPrefix() {
@@ -127,9 +127,9 @@
 		/**/.text( i18n.buttonUpdateCache )
 		/**/.button()
 		/**/.click( function() {
-			dialog.dialog( 'close' );
-			updateCache();
-		} )
+				dialog.dialog( 'close' );
+				updateCache();
+			} )
 		/**/.appendTo( dialog );
 		$( document.createElement( "br" ) ).appendTo( dialog );
 
@@ -161,8 +161,8 @@
 			url: getWikidataApiPrefix() + '&action=wbgetentities&ids=' + entityId,
 			dataType: 'json',
 			success: function( result ) {
-				var entity = result.entities[entityId];
-				var api = ( new mw.Api() );
+				var entity = result.entities[ entityId ];
+				var api = new mw.Api();
 
 				jsMsg( i18n.statusGenerateLua );
 				var lua = generateLua( entity );
@@ -170,27 +170,27 @@
 				jsMsg( i18n.statusUpdatingCache );
 				$.when(
 
-				api.postWithEditToken( {
-					action: 'edit',
-					format: 'json',
-					title: PREFIX + entityId.toUpperCase(),
-					summary: i18n.summary,
-					text: lua,
-				}, function() {
-					// ok
-				}, function( text, data ) {
-					// error
-					alert( i18n.errorUpdatingCache + ': ' + text );
-				} ),
+					api.postWithEditToken( {
+						action: 'edit',
+						format: 'json',
+						title: PREFIX + entityId.toUpperCase(),
+						summary: i18n.summary,
+						text: lua,
+					}, function() {
+						// ok
+					}, function( text /*, data */ ) {
+						// error
+						alert( i18n.errorUpdatingCache + ': ' + text );
+					} ),
 
-				api.postWithEditToken( {
-					action: 'edit',
-					format: 'json',
-					title: PREFIX + entityId + '/doc',
-					summary: i18n.summary,
-					createonly: 1,
-					text: MODULE_DOC,
-				} )
+					api.postWithEditToken( {
+						action: 'edit',
+						format: 'json',
+						title: PREFIX + entityId + '/doc',
+						summary: i18n.summary,
+						createonly: 1,
+						text: MODULE_DOC,
+					} )
 
 				).done( function() {
 					jsMsg( i18n.statusUpdateDonePurge );
@@ -212,7 +212,7 @@
 	function repeat( str, count ) {
 		var result = "";
 		for ( var i = 0; i < count; i++ ) {
-			result = result + str;
+			result += str;
 		}
 		return result;
 	}
@@ -239,20 +239,19 @@
 			return result + '}';
 		} else if ( typeof value === 'object' ) {
 			var result = '{';
-			for ( var key in value ) {
-				var subvalue = value[key];
+			Object.keys( value ).forEach( function( key ) {
+				var subvalue = value[ key ];
 				var subResult = generateLuaImpl( subvalue, level + 1 );
 				if ( subResult ) {
 					result = result + '\n' + repeat( '\t', level ) + generateLuaLabel( key ) + " = " + subResult + ',';
 				}
-			}
+			} );
 			return result + '\n' + repeat( '\t', level - 1 ) + '}';
 		}
-		return;
 	}
 
 	function generateLuaLabel( key ) {
-		if ( /^[a-zA-Z][a-zA-Z0-9\_]*$/.exec( key ) ) {
+		if ( /^[a-zA-Z][a-zA-Z0-9_]*$/.exec( key ) ) {
 			return key;
 		}
 		return "['" + escapeForLua( key ) + "']";
@@ -263,19 +262,19 @@
 		jsMsg( i18n.statusRemovingCache );
 
 		var entityId = mw.config.get( 'wgWikibaseItemId' ).toUpperCase();
-		var api = ( new mw.Api() );
+		var api = new mw.Api();
 
 		$.when(
 
-		api.postWithToken( 'delete', {
-			action: 'delete',
-			title: PREFIX + entityId,
-		} ),
+			api.postWithToken( 'delete', {
+				action: 'delete',
+				title: PREFIX + entityId,
+			} ),
 
-		api.postWithToken( 'delete', {
-			action: 'delete',
-			title: PREFIX + entityId + '/doc',
-		} )
+			api.postWithToken( 'delete', {
+				action: 'delete',
+				title: PREFIX + entityId + '/doc',
+			} )
 
 		).done( function() {
 			jsMsg( i18n.statusDeleteDonePurge );
@@ -305,14 +304,14 @@
 			url: '/w/api.php?format=json&action=query&prop=revisions&titles=Module:WikidataCache/' + entityId.toUpperCase() + '&rvprop=' + encodeURIComponent( 'content|ids' ),
 			dataType: 'json',
 		} ) ).done( function( wikidataResponse, wikipediaResponse ) {
-			var wikidataPage = getFirstObjectValue( wikidataResponse[0].query.pages );
+			var wikidataPage = getFirstObjectValue( wikidataResponse[ 0 ].query.pages );
 
 			if ( typeof wikidataPage.missing !== "undefined" ) {
 				mw.log.warn( 'Entity is missing on Wikidata: ' + entityId );
 				return;
 			}
 
-			var wikipediaPage = getFirstObjectValue( wikipediaResponse[0].query.pages );
+			var wikipediaPage = getFirstObjectValue( wikipediaResponse[ 0 ].query.pages );
 			if ( typeof wikipediaPage.missing !== "undefined" ) {
 
 				// cache is missed
@@ -324,9 +323,9 @@
 
 			} else {
 				// check revision
-				var content = wikipediaPage.revisions[0]["*"];
-				var storedRevision = Number( content.match( /lastrevid\s*\=\s*\s*([0-9]+),/ )[1] );
-				var existedRevision = Number( wikidataPage.revisions[0].revid );
+				var content = wikipediaPage.revisions[ 0 ][ "*" ];
+				var storedRevision = Number( content.match( /lastrevid\s*=\s*\s*([0-9]+),/ )[ 1 ] );
+				var existedRevision = Number( wikidataPage.revisions[ 0 ].revid );
 
 				if ( storedRevision === existedRevision ) {
 

--- a/gadget/Gadget-wefinfobox.js
+++ b/gadget/Gadget-wefinfobox.js
@@ -17,9 +17,9 @@ mediaWiki.loader.using( [ 'ext.gadget.wefcore', 'jquery.ui.button', 'wikibase.fo
 			 * Valueview expert for wb.datamodel.EntityId. This is a simple
 			 * expert, only handling the input, based on the StringValue input
 			 * but with the jQuery.wikibase.entityselector for convenience.
-			 * 
+			 *
 			 * @since 0.4
-			 * 
+			 *
 			 * @constructor
 			 * @extends jQuery.valueview.experts.StringValue
 			 */
@@ -45,9 +45,9 @@ mediaWiki.loader.using( [ 'ext.gadget.wefcore', 'jquery.ui.button', 'wikibase.fo
 					var entityId = value && value.getPrefixedId( WB_ENTITIES_PREFIXMAP );
 
 					this.$input.data( 'entityselector' ).selectedEntity( entityId );
-					$input.on( 'eachchange.' + this.uiBaseClass, function( e ) {
+					$input.on( 'eachchange.' + this.uiBaseClass, function( /* e */ ) {
 						$( this ).data( 'entityselector' ).repositionMenu();
-					} ).on( 'entityselectorselected.' + this.uiBaseClass, function( e ) {
+					} ).on( 'entityselectorselected.' + this.uiBaseClass, function( /* e */ ) {
 						self._resizeInput();
 						notifier.notify( 'change' );
 					} );
@@ -72,7 +72,7 @@ mediaWiki.loader.using( [ 'ext.gadget.wefcore', 'jquery.ui.button', 'wikibase.fo
 
 				/**
 				 * @see jQuery.valueview.Expert.rawValue
-				 * 
+				 *
 				 * @return string
 				 */
 				rawValue: function() {
@@ -83,7 +83,7 @@ mediaWiki.loader.using( [ 'ext.gadget.wefcore', 'jquery.ui.button', 'wikibase.fo
 
 				/**
 				 * @see jQuery.valueview.Expert.valueCharacteristics
-				 * 
+				 *
 				 * TODO: remove this once the parsing is done via API
 				 */
 				valueCharacteristics: function() {

--- a/gadget/Gadget-wefok.js
+++ b/gadget/Gadget-wefok.js
@@ -1,74 +1,74 @@
 /**
  * This JavaScript is a implementation of JavaScript Gadget to edit common
  * entity information on Wikidata. This script is based on WE-Framework.
- * 
+ *
  * @see https://github.com/vlsergey/WE-Framework
  * @author vlsergey
  */
-var wef_OkEditor_html = "<div class=\'wef_dialog\'>\r\n" + 
-		"	<div class=\'wef_tabs\'>\r\n" + 
-		"		<ul>\r\n" + 
-		"			<li><a href=\'#wef_entityEditor_tab_general\' class=\'wef_editor_tab_anchor wef_i18n_text\'>groupGeneral</a></li>\r\n" + 
-		"			<li><a href=\'#wef_entityEditor_tab_sources\' class=\'wef_editor_tab_anchor wef_i18n_label\'>P1343</a></li>\r\n" + 
-		"		</ul>\r\n" + 
-		"		<div id=\'wef_entityEditor_tab_general\' class=\'wef_editor_tab\'>\r\n" + 
-		"			<div class=\"wef_labels_editor\"></div>\r\n" + 
-		"			<fieldset class=\'wef_single_property_fieldset\'>\r\n" + 
-		"				<legend class=\'wef_i18n_label\'>P279</legend>\r\n" + 
-		"				<table class=\'wef_table\'>\r\n" + 
-		"					<!-- subclass of -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P279\' data-datatype=\'wikibase-item\' >\r\n" + 
-		"						<tr data-code=\'P1013\' data-datatype=\'wikibase-item\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"				</table>\r\n" + 
-		"			</fieldset>\r\n" + 
-		"			<fieldset>\r\n" + 
-		"				<legend class=\'wef_i18n_label\'>Q4330198</legend>\r\n" + 
-		"				<table class=\'wef_table\'>\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P3248\' data-datatype=\'external-id\'>\r\n" + 
-		"						<tr data-code=\'P1448\' data-datatype=\'monolingualtext\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P3245\' data-datatype=\'external-id\'>\r\n" + 
-		"						<tr data-code=\'P1448\' data-datatype=\'monolingualtext\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P3250\' data-datatype=\'external-id\'>\r\n" + 
-		"						<tr data-code=\'P1448\' data-datatype=\'monolingualtext\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"				</table>\r\n" + 
-		"			</fieldset>\r\n" + 
-		"			<fieldset>\r\n" + 
-		"				<legend class=\'wef_i18n_label\'>Q19192441</legend>\r\n" + 
-		"				<table class=\'wef_table\'>\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P3243\' data-datatype=\'external-id\'>\r\n" + 
-		"						<tr data-code=\'P1448\' data-datatype=\'monolingualtext\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P3246\' data-datatype=\'external-id\'>\r\n" + 
-		"						<tr data-code=\'P1448\' data-datatype=\'monolingualtext\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"				</table>\r\n" + 
-		"			</fieldset>\r\n" + 
-		"		</div>\r\n" + 
-		"		<div id=\'wef_entityEditor_tab_sources\' class=\'wef_editor_tab\'>\r\n" + 
-		"			<fieldset class=\'wef_single_property_fieldset\'>\r\n" + 
-		"				<legend class=\'wef_i18n_label\'>P1343</legend>\r\n" + 
-		"				<table class=\'wef_table\'>\r\n" + 
-		"					<!-- described by source -->\r\n" + 
-		"					<tbody class=\'wef_claim_editors\' data-code=\'P1343\' data-datatype=\'wikibase-item\'>\r\n" + 
-		"						<!-- stated in -->\r\n" + 
-		"						<tr data-code=\'P248\' data-datatype=\'wikibase-item\' />\r\n" + 
-		"						<!-- section, verse, or paragraph -->\r\n" + 
-		"						<tr data-code=\'P958\' data-datatype=\'string\' />\r\n" + 
-		"						<!-- volume -->\r\n" + 
-		"						<tr data-code=\'P478\' data-datatype=\'string\' />\r\n" + 
-		"						<!-- page -->\r\n" + 
-		"						<tr data-code=\'P304\' data-datatype=\'string\' />\r\n" + 
-		"						<!-- reference URL -->\r\n" + 
-		"						<tr data-code=\'P854\' data-datatype=\'url\' />\r\n" + 
-		"					</tbody>\r\n" + 
-		"				</table>\r\n" + 
-		"			</fieldset>\r\n" + 
-		"		</div>\r\n" + 
-		"	</div>\r\n" + 
+var wef_OkEditor_html = "<div class=\'wef_dialog\'>\r\n" +
+		"	<div class=\'wef_tabs\'>\r\n" +
+		"		<ul>\r\n" +
+		"			<li><a href=\'#wef_entityEditor_tab_general\' class=\'wef_editor_tab_anchor wef_i18n_text\'>groupGeneral</a></li>\r\n" +
+		"			<li><a href=\'#wef_entityEditor_tab_sources\' class=\'wef_editor_tab_anchor wef_i18n_label\'>P1343</a></li>\r\n" +
+		"		</ul>\r\n" +
+		"		<div id=\'wef_entityEditor_tab_general\' class=\'wef_editor_tab\'>\r\n" +
+		"			<div class=\"wef_labels_editor\"></div>\r\n" +
+		"			<fieldset class=\'wef_single_property_fieldset\'>\r\n" +
+		"				<legend class=\'wef_i18n_label\'>P279</legend>\r\n" +
+		"				<table class=\'wef_table\'>\r\n" +
+		"					<!-- subclass of -->\r\n" +
+		"					<tbody class=\'wef_claim_editors\' data-code=\'P279\' data-datatype=\'wikibase-item\' >\r\n" +
+		"						<tr data-code=\'P1013\' data-datatype=\'wikibase-item\' />\r\n" +
+		"					</tbody>\r\n" +
+		"				</table>\r\n" +
+		"			</fieldset>\r\n" +
+		"			<fieldset>\r\n" +
+		"				<legend class=\'wef_i18n_label\'>Q4330198</legend>\r\n" +
+		"				<table class=\'wef_table\'>\r\n" +
+		"					<tbody class=\'wef_claim_editors\' data-code=\'P3248\' data-datatype=\'external-id\'>\r\n" +
+		"						<tr data-code=\'P1448\' data-datatype=\'monolingualtext\' />\r\n" +
+		"					</tbody>\r\n" +
+		"					<tbody class=\'wef_claim_editors\' data-code=\'P3245\' data-datatype=\'external-id\'>\r\n" +
+		"						<tr data-code=\'P1448\' data-datatype=\'monolingualtext\' />\r\n" +
+		"					</tbody>\r\n" +
+		"					<tbody class=\'wef_claim_editors\' data-code=\'P3250\' data-datatype=\'external-id\'>\r\n" +
+		"						<tr data-code=\'P1448\' data-datatype=\'monolingualtext\' />\r\n" +
+		"					</tbody>\r\n" +
+		"				</table>\r\n" +
+		"			</fieldset>\r\n" +
+		"			<fieldset>\r\n" +
+		"				<legend class=\'wef_i18n_label\'>Q19192441</legend>\r\n" +
+		"				<table class=\'wef_table\'>\r\n" +
+		"					<tbody class=\'wef_claim_editors\' data-code=\'P3243\' data-datatype=\'external-id\'>\r\n" +
+		"						<tr data-code=\'P1448\' data-datatype=\'monolingualtext\' />\r\n" +
+		"					</tbody>\r\n" +
+		"					<tbody class=\'wef_claim_editors\' data-code=\'P3246\' data-datatype=\'external-id\'>\r\n" +
+		"						<tr data-code=\'P1448\' data-datatype=\'monolingualtext\' />\r\n" +
+		"					</tbody>\r\n" +
+		"				</table>\r\n" +
+		"			</fieldset>\r\n" +
+		"		</div>\r\n" +
+		"		<div id=\'wef_entityEditor_tab_sources\' class=\'wef_editor_tab\'>\r\n" +
+		"			<fieldset class=\'wef_single_property_fieldset\'>\r\n" +
+		"				<legend class=\'wef_i18n_label\'>P1343</legend>\r\n" +
+		"				<table class=\'wef_table\'>\r\n" +
+		"					<!-- described by source -->\r\n" +
+		"					<tbody class=\'wef_claim_editors\' data-code=\'P1343\' data-datatype=\'wikibase-item\'>\r\n" +
+		"						<!-- stated in -->\r\n" +
+		"						<tr data-code=\'P248\' data-datatype=\'wikibase-item\' />\r\n" +
+		"						<!-- section, verse, or paragraph -->\r\n" +
+		"						<tr data-code=\'P958\' data-datatype=\'string\' />\r\n" +
+		"						<!-- volume -->\r\n" +
+		"						<tr data-code=\'P478\' data-datatype=\'string\' />\r\n" +
+		"						<!-- page -->\r\n" +
+		"						<tr data-code=\'P304\' data-datatype=\'string\' />\r\n" +
+		"						<!-- reference URL -->\r\n" +
+		"						<tr data-code=\'P854\' data-datatype=\'url\' />\r\n" +
+		"					</tbody>\r\n" +
+		"				</table>\r\n" +
+		"			</fieldset>\r\n" +
+		"		</div>\r\n" +
+		"	</div>\r\n" +
 		"</div>";
 
 window.wef_OkEditor_i18n_en = {

--- a/gadget/Gadget-wefsources.js
+++ b/gadget/Gadget-wefsources.js
@@ -11,7 +11,7 @@
 
 	/**
 	 * @const
-	 * 
+	 *
 	 * @type {String[]}
 	 */
 	var WEF_SOURCES_LOOKUP_LANGUAGES = ( function() {
@@ -66,7 +66,7 @@
 	/**
 	 * @class
 	 */
-	WEF_SelectOrFindSourceForm = function() {
+	var WEF_SelectOrFindSourceForm = function() {
 
 		var form = this;
 		var html = this._html = $( '<div class="wefSelectOrFindSourceForm"></div>' );
@@ -170,10 +170,10 @@
 	/**
 	 * @class
 	 */
-	WEF_SelectOrFindSourceForm_List = function() {
+	var WEF_SelectOrFindSourceForm_List = function() {
 		this._map = {};
 		this.htmlElement = $( '<div class="wefSelectOrFindSourceForm_list">' );
-		this.statusElement = $( '<p></p>').appendTo(this.htmlElement);
+		this.statusElement = $( '<p></p>' ).appendTo( this.htmlElement );
 	};
 
 	WEF_SelectOrFindSourceForm_List.prototype.latest = function( entityIds ) {
@@ -192,7 +192,7 @@
 
 		list.searchesInProgress = 0;
 		$.each( WEF_SOURCES_LOOKUP_LANGUAGES, function( i, languageCode ) {
-			list.statusElement.text("Looking for sources by term «" + searchTerm + "»...");
+			list.statusElement.text( "Looking for sources by term «" + searchTerm + "»..." );
 			list.statusElement.show();
 
 			list.searchesInProgress++;
@@ -209,7 +209,7 @@
 					if ( alreadyAdded.hasOwnProperty( entity.id ) ) {
 						return;
 					}
-					alreadyAdded[entity.id] = true;
+					alreadyAdded[ entity.id ] = true;
 					alreadyAddedCount++;
 					entityIds.push( entity.id );
 				} );
@@ -217,8 +217,8 @@
 
 				list.searchesInProgress--;
 				if ( list.searchesInProgress == 0 ) {
-					if ( alreadyAddedCount == 0) {
-						list.statusElement.text("Nothing found by term «" + searchTerm + "»");
+					if ( alreadyAddedCount == 0 ) {
+						list.statusElement.text( "Nothing found by term «" + searchTerm + "»" );
 						list.statusElement.show();
 					} else {
 						list.statusElement.hide();
@@ -241,7 +241,7 @@
 		var list = this;
 		$.each( entityIds, function( index, entityId ) {
 			var item = new WEF_SelectOrFindSourceForm_List_Item( entityId );
-			list._map[entityId] = item;
+			list._map[ entityId ] = item;
 			list.htmlElement.append( item.htmlElement );
 		} );
 
@@ -263,7 +263,7 @@
 			$.each( getEntitiesResult.entities, function( entityIndex, entity ) {
 				var entityId = entity.id;
 				/** @type {WEF_SelectOrFindSourceForm_List_Item} */
-				var item = list._map[entityId];
+				var item = list._map[ entityId ];
 				if ( typeof item === 'undefined' ) {
 					return;
 				}
@@ -297,15 +297,15 @@
 						return;
 					}
 
-					var text = parseResult.parse.text['*'];
+					var text = parseResult.parse.text[ '*' ];
 					if ( !WEF_Utils.isEmpty( text ) ) {
 						item.visualElement.html( text );
 					}
-				} ).fail( function( jqXHR, textStatus, errorThrown ) {
+				} ).fail( function( jqXHR, textStatus /* , errorThrown */ ) {
 					mw.log( textStatus );
 				} );
 			} );
-		} ).fail( function( jqXHR, textStatus, errorThrown ) {
+		} ).fail( function( jqXHR, textStatus /* , errorThrown */ ) {
 			mw.log( textStatus );
 		} );
 	};
@@ -313,7 +313,7 @@
 	/**
 	 * @class
 	 */
-	WEF_SelectOrFindSourceForm_List_Item = function( entityId ) {
+	var WEF_SelectOrFindSourceForm_List_Item = function( entityId ) {
 		WEF_Utils.assertCorrectEntityId( entityId );
 		this.entityId = entityId;
 
@@ -372,29 +372,29 @@
 		var parameters = $( '<table class="wefInsertSourceFormParameters"></div>' ).appendTo( html );
 
 		var inputPart = $( '<input class="wefInsertSourceForm_input" id="wefInsertSourceForm_input_part">' ).appendTo(
-				$( '<td></td>' ).appendTo(
-						$( '<tr class="wefInsertSourceForm_labelAndInput">' ).append(
-								$( '<th><label for="wefInsertSourceForm_input_part">Название главы, части или раздела:</label></th>' ) ).appendTo( parameters ) ) );
+			$( '<td></td>' ).appendTo(
+				$( '<tr class="wefInsertSourceForm_labelAndInput">' ).append(
+					$( '<th><label for="wefInsertSourceForm_input_part">Название главы, части или раздела:</label></th>' ) ).appendTo( parameters ) ) );
 
 		var inputUrl = $( '<input class="wefInsertSourceForm_input" id="wefInsertSourceForm_input_url">' ).appendTo(
-				$( '<td></td>' ).appendTo(
-						$( '<tr class="wefInsertSourceForm_labelAndInput">' ).append(
-								$( '<th><label for="wefInsertSourceForm_input_url">URL для главы, части или раздела:</label></th>' ) ).appendTo( parameters ) ) );
+			$( '<td></td>' ).appendTo(
+				$( '<tr class="wefInsertSourceForm_labelAndInput">' ).append(
+					$( '<th><label for="wefInsertSourceForm_input_url">URL для главы, части или раздела:</label></th>' ) ).appendTo( parameters ) ) );
 
 		var inputPages = $( '<input class="wefInsertSourceForm_input" id="wefInsertSourceForm_input_pages">' ).appendTo(
-				$( '<td></td>' ).appendTo(
-						$( '<tr class="wefInsertSourceForm_labelAndInput">' ).append( $( '<th><label for="wefInsertSourceForm_input_pages">Номера страниц:</label></th>' ) )
-								.appendTo( parameters ) ) );
+			$( '<td></td>' ).appendTo(
+				$( '<tr class="wefInsertSourceForm_labelAndInput">' ).append( $( '<th><label for="wefInsertSourceForm_input_pages">Номера страниц:</label></th>' ) )
+					.appendTo( parameters ) ) );
 
 		var inputVolume = $( '<input class="wefInsertSourceForm_input" id="wefInsertSourceForm_input_volume">' ).appendTo(
-				$( '<td></td>' ).appendTo(
-						$( '<tr class="wefInsertSourceForm_labelAndInput">' ).append( $( '<th><label for="wefInsertSourceForm_input_volume">Том:</label></th>' ) ).appendTo(
-								parameters ) ) );
+			$( '<td></td>' ).appendTo(
+				$( '<tr class="wefInsertSourceForm_labelAndInput">' ).append( $( '<th><label for="wefInsertSourceForm_input_volume">Том:</label></th>' ) ).appendTo(
+					parameters ) ) );
 
 		var inputIssue = $( '<input class="wefInsertSourceForm_input" id="wefInsertSourceForm_input_issue">' ).appendTo(
-				$( '<td></td>' ).appendTo(
-						$( '<tr class="wefInsertSourceForm_labelAndInput">' ).append( $( '<th><label for="wefInsertSourceForm_input_issue">Выпуск:</label></th>' ) ).appendTo(
-								parameters ) ) );
+			$( '<td></td>' ).appendTo(
+				$( '<tr class="wefInsertSourceForm_labelAndInput">' ).append( $( '<th><label for="wefInsertSourceForm_input_issue">Выпуск:</label></th>' ) ).appendTo(
+					parameters ) ) );
 
 		$( '<hr>' ).appendTo( html );
 		$( '<p>Если Вам необходимо указать другие параметры, например, автора или год публикации, нужно завести отдельный элемент источника.</p>' ).appendTo( html );
@@ -403,7 +403,7 @@
 		var wikitextParameters = $( '<table class="wefInsertSourceFormParameters"></div>' ).appendTo( html );
 
 		var checkboxAsRef = $( '<input type="checkbox" class="wefInsertSourceForm_checkbox">' );
-		appendCheckboxRow( checkboxAsRef, 'Вставить как сноску', $(''), wikitextParameters );
+		appendCheckboxRow( checkboxAsRef, 'Вставить как сноску', $( '' ), wikitextParameters );
 
 		var checkboxRefAuthor = $( '<input type="checkbox" class="wefInsertSourceForm_checkbox" checked>' );
 		var inputRefAuthor = $( '<input class="wefInsertSourceForm_input">' );
@@ -505,12 +505,12 @@
 			$toolbar = $( '#toolbar' );
 		}
 		$( '<div>' ) //
-		.addClass( 'mw-toolbar-editbutton' ) //
-		.attr( 'alt', 'Вставить ссылку на источник' ) //
-		.attr( 'title', 'Вставить ссылку на источник' ) //
-		.css( 'background-image', 'url(//upload.wikimedia.org/wikipedia/commons/b/b8/Bouton_Faut_sourcer.png)' ) //
-		.appendTo( $toolbar ) //
-		.on( 'click', new WEF_SelectOrFindSourceForm().display() );
+			.addClass( 'mw-toolbar-editbutton' ) //
+			.attr( 'alt', 'Вставить ссылку на источник' ) //
+			.attr( 'title', 'Вставить ссылку на источник' ) //
+			.css( 'background-image', 'url(//upload.wikimedia.org/wikipedia/commons/b/b8/Bouton_Faut_sourcer.png)' ) //
+			.appendTo( $toolbar ) //
+			.on( 'click', new WEF_SelectOrFindSourceForm().display() );
 	}
 
 	function addNewToolbarButton() {
@@ -524,7 +524,7 @@
 					icon: '//upload.wikimedia.org/wikipedia/commons/b/b8/Bouton_Faut_sourcer.png',
 					action: {
 						type: 'callback',
-						execute: function( context ) {
+						execute: function( /* context */ ) {
 							new WEF_SelectOrFindSourceForm().display();
 						}
 					}
@@ -555,12 +555,17 @@
 
 	$.each( window.wef_editors_registry.registry, function( classId, editor ) {
 
-		$( '.citetype_' + classId ).prepend( $( document.createElement( 'a' ) ).addClass( 'wef_attached_edit' ).text( '[edit] ' ).css( 'cursor', 'pointer' ).click( function() {
-			var entityId = $( this ).parent().data( 'entity-id' );
-			if ( !WEF_Utils.isEmpty( entityId ) ) {
-				editor.edit( false, entityId );
-			}
-		} ) );
+		$( '.citetype_' + classId ).prepend(
+			$( document.createElement( 'a' ) )
+				.addClass( 'wef_attached_edit' )
+				.text( '[edit] ' )
+				.css( 'cursor', 'pointer' )
+				.click( function() {
+					var entityId = $( this ).parent().data( 'entity-id' );
+					if ( !WEF_Utils.isEmpty( entityId ) ) {
+						editor.edit( false, entityId );
+					}
+				} ) );
 
 	} );
 

--- a/gadget/Gadget-wefwatchlist.js
+++ b/gadget/Gadget-wefwatchlist.js
@@ -52,10 +52,10 @@ if ( mw.config.get( 'wgCanonicalSpecialPageName' ) === 'Watchlist' ) {
 				mw.log.warn( "List to get from Wikidata: " + titles.join( '|' ) );
 
 				var newWRcontinue = false;
-				if ( typeof result["continue"] !== 'undefined' //
-						&& typeof result["continue"] !== 'undefined' //
-						&& typeof result["continue"].wrcontinue !== 'undefined' ) {
-					newWRcontinue = result["continue"].wrcontinue;
+				if ( typeof result[ "continue" ] !== 'undefined' //
+						&& typeof result[ "continue" ] !== 'undefined' //
+						&& typeof result[ "continue" ].wrcontinue !== 'undefined' ) {
+					newWRcontinue = result[ "continue" ].wrcontinue;
 				}
 				if ( newWRcontinue ) {
 					asyncGetWatchlistRaw( newWRcontinue );
@@ -77,7 +77,7 @@ if ( mw.config.get( 'wgCanonicalSpecialPageName' ) === 'Watchlist' ) {
 				props: 'info',
 				titles: titles.join( '|' ),
 			} ).done( function( result ) {
-				$.each( result.entities, function( key, item ) {
+				$.each( result.entities, function( key /* , item */ ) {
 					if ( /^Q[0-9]+$/.test( key ) ) {
 						qIds.push( key );
 					}
@@ -153,7 +153,7 @@ if ( mw.config.get( 'wgCanonicalSpecialPageName' ) === 'Watchlist' ) {
 				$.each( changeList.children( 'h4' ), function( i, h4 ) {
 					var jH4 = $( h4 );
 					var firstDiv = jH4.find( '~ div' ).first();
-					headers[jH4.text()] = {
+					headers[ jH4.text() ] = {
 						header: jH4,
 						firstDiv: firstDiv,
 						firstDivChildren: firstDiv.children(),
@@ -185,12 +185,12 @@ if ( mw.config.get( 'wgCanonicalSpecialPageName' ) === 'Watchlist' ) {
 			"use strict";
 
 			var updatedString = jEntry.children( 'updated' ).text();
-			var tzOffset = parseInt( mw.user.options.get( 'timecorrection' ).split( '|' )[1], 10 ) + new Date().getTimezoneOffset();
+			var tzOffset = parseInt( mw.user.options.get( 'timecorrection' ).split( '|' )[ 1 ], 10 ) + new Date().getTimezoneOffset();
 			var updated = new Date( Date.parse( updatedString ) + tzOffset * 60 * 1000 );
-			var date = updated.getDate() + ' ' + i18n.monthes[updated.getMonth()] + ' ' + updated.getFullYear();
+			var date = updated.getDate() + ' ' + i18n.monthes[ updated.getMonth() ] + ' ' + updated.getFullYear();
 
-			if ( typeof headers[date] !== 'undefined' ) {
-				var pregenerated = headers[date];
+			if ( typeof headers[ date ] !== 'undefined' ) {
+				var pregenerated = headers[ date ];
 				var firstDiv = pregenerated.firstDiv;
 				var firstDivChildren = pregenerated.firstDivChildren;
 
@@ -206,7 +206,7 @@ if ( mw.config.get( 'wgCanonicalSpecialPageName' ) === 'Watchlist' ) {
 
 					var timeOfElement = jChild.data( 'wef-parsed-time' );
 					if ( typeof timeOfElement === 'undefined' ) {
-						timeOfElement = $( jChild.find( 'td.mw-enhanced-rc' )[0] ).text().substring( 6 ).trim();
+						timeOfElement = $( jChild.find( 'td.mw-enhanced-rc' )[ 0 ] ).text().substring( 6 ).trim();
 						jChild.data( 'wef-parsed-time', timeOfElement );
 					}
 
@@ -238,12 +238,12 @@ if ( mw.config.get( 'wgCanonicalSpecialPageName' ) === 'Watchlist' ) {
 			var firstLine = $( document.createElement( 'tr' ) ).appendTo( table );
 
 			var toggleIcon = $( document.createElement( 'span' ) ).addClass( 'mw-collapsible-toggle' ).addClass( 'mw-collapsible-arrow' ).addClass( 'mw-enhancedchanges-arrow' )
-					.addClass( 'mw-enhancedchanges-arrow-space' ).addClass( 'mw-collapsible-toggle-collapsed' );
+				.addClass( 'mw-enhancedchanges-arrow-space' ).addClass( 'mw-collapsible-toggle-collapsed' );
 			var toggle = $( document.createElement( 'td' ) ).append( toggleIcon ).appendTo( firstLine );
 
 			$( document.createElement( 'td' ) ).addClass( 'mw-enhanced-rc' ).html(
-					"<abbr class=\'wikidata\' title=\'" + i18n.linePartTooltip + "\'>" + i18n.linePartLetter + "</abbr>&#160;&#160;&#160;&#160;&#160;" + time + "&#160;" )
-					.appendTo( firstLine );
+				"<abbr class='wikidata' title='" + i18n.linePartTooltip + "'>" + i18n.linePartLetter + "</abbr>&#160;&#160;&#160;&#160;&#160;" + time + "&#160;" )
+				.appendTo( firstLine );
 
 			var title = $( document.createElement( 'a' ) ).addClass( 'mw-changeslist-title' ).attr( 'href', '//www.wikidata.org/wiki/' + id ).text( id );
 			window.wef_LabelsCache.localizeLabel( title, id );
@@ -254,11 +254,11 @@ if ( mw.config.get( 'wgCanonicalSpecialPageName' ) === 'Watchlist' ) {
 			mainLine.append( $( document.createElement( 'a' ) ).text( i18n.linePartChange ).attr( 'href', changeUrl ) );
 			mainLine.append( " | " );
 			mainLine.append( $( document.createElement( 'a' ) ).text( i18n.linePartHistory ).attr( 'href',
-					'//www.wikidata.org/w/index.php?action=history&title=' + encodeURIComponent( id ) ) );
+				'//www.wikidata.org/w/index.php?action=history&title=' + encodeURIComponent( id ) ) );
 			mainLine.append( ")" );
 			mainLine.append( $( document.createElement( 'span' ) ).addClass( 'mw-changeslist-separator' ).text( '. .' ) );
 			mainLine.append( $( document.createElement( 'a' ) ).addClass( 'mw-userlink' ).addClass( 'userlink' ).text( author ).attr( 'href',
-					'//www.wikidata.org/wiki/User:' + author ) );
+				'//www.wikidata.org/wiki/User:' + author ) );
 			mainLine.append( $( document.createElement( 'span' ) ).addClass( 'mw-changeslist-separator' ).text( '. .' ) );
 			mainLine.appendTo( firstLine );
 
@@ -268,7 +268,7 @@ if ( mw.config.get( 'wgCanonicalSpecialPageName' ) === 'Watchlist' ) {
 			secondLine.append( $( document.createElement( 'td' ) ).addClass( 'mw-enhanced-rc-nested' ).html( jEntry.children( 'summary' ).text() ) );
 			secondLine.appendTo( table );
 
-			var summaryElement = $( secondLine.children( 'td' )[2] );
+			var summaryElement = $( secondLine.children( 'td' )[ 2 ] );
 			localizeSummary( summaryElement );
 
 			var firstPOfSummary = summaryElement.children( 'p' ).first();

--- a/gadget/WEF_AllEditors.js
+++ b/gadget/WEF_AllEditors.js
@@ -1,7 +1,7 @@
 /**
  * This JavaScript is a loader of EditionEditor from WE-Framework, works only
  * for other sites (ruwiki users should use local gadgets)
- * 
+ *
  * @see https://github.com/vlsergey/WE-Framework
  * @author vlsergey
  */
@@ -13,10 +13,10 @@
 	try {
 		mw.loader.addSource( "ruwiki", "//ru.wikipedia.org/w/load.php" );
 		mw.loader.register( 'ext.gadget.wefcore', version, [ 'jquery.ui.autocomplete', //
-		'jquery.ui.dialog', //
-		'jquery.ui.tabs', //
-		'jquery.uls.data', //
-		'mediawiki.ForeignApi', //
+				'jquery.ui.dialog', //
+				'jquery.ui.tabs', //
+				'jquery.uls.data', //
+				'mediawiki.ForeignApi', //
 		], undefined, 'ruwiki' );
 		mw.loader.register( 'ext.gadget.isbnjs', version, undefined, undefined, 'ruwiki' );
 		mw.loader.register( 'ext.gadget.wefflags', version, undefined, undefined, 'ruwiki' );
@@ -39,22 +39,22 @@
 	mw.loader.register( 'ext.gadget.wef-WorkEditor', version, [ 'ext.gadget.wefcore', 'ext.gadget.wefflags', ], undefined, 'ruwiki' );
 
 	mw.loader.using( [ //
-	'ext.gadget.wefcore', //
-	'ext.gadget.isbnjs', //
-	'ext.gadget.wefflags', //
-	'ext.gadget.wef-AdmUnitEditor', //
-	'ext.gadget.wef-ArticleEditor', //
-	'ext.gadget.wef-BookEditor', //
-	'ext.gadget.wef-DocumentEditor', //
-	'ext.gadget.wef-EditionEditor', //
-	'ext.gadget.wef-EntityEditor', //
-	'ext.gadget.wef-ExternalLinks', //
-	'ext.gadget.wef-MovieEditor', // 
-	'ext.gadget.wef-OkEditor', // 
-	'ext.gadget.wef-PersonEditor', //
-	'ext.gadget.wef-SoftwareEditor', //
-	'ext.gadget.wef-TaxonEditor', //
-	'ext.gadget.wef-WorkEditor' //
+			'ext.gadget.wefcore', //
+			'ext.gadget.isbnjs', //
+			'ext.gadget.wefflags', //
+			'ext.gadget.wef-AdmUnitEditor', //
+			'ext.gadget.wef-ArticleEditor', //
+			'ext.gadget.wef-BookEditor', //
+			'ext.gadget.wef-DocumentEditor', //
+			'ext.gadget.wef-EditionEditor', //
+			'ext.gadget.wef-EntityEditor', //
+			'ext.gadget.wef-ExternalLinks', //
+			'ext.gadget.wef-MovieEditor', //
+			'ext.gadget.wef-OkEditor', //
+			'ext.gadget.wef-PersonEditor', //
+			'ext.gadget.wef-SoftwareEditor', //
+			'ext.gadget.wef-TaxonEditor', //
+			'ext.gadget.wef-WorkEditor' //
 	], function() {
 		console.log( '[WE-F] all WE-F modules were loaded' );
 	}, function() {

--- a/src/.eslintrc.js
+++ b/src/.eslintrc.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  "globals": {
+    "process": false,
+  },
+};

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,8 +1,12 @@
 'use strict';
 
 module.exports = {
+  "globals": {
+    "describe": true,
+    "it": true,
+  },
   "rules": {
     "react/jsx-no-bind": 0,
     "react/no-find-dom-node": 0,
   },
-}
+};


### PR DESCRIPTION
* added gadgets .eslintrc.js overrides, disabling many root-level rules
* Use `===` and `!==` instead of `==` and `!=`
* do not use `for (var key in obj) {}` because key might not be a real key in the object. Replace with `Object.keys( obj ).forEach( function ( key ) {...});`.  Not my fav, I prefer `for ... of`, but that might be broken on older browsers (?)
* Some spacing issues