### PR TITLE
Parametrize wikidata.org and WDQS

### DIFF
--- a/src/caches/parentTypesCache.js
+++ b/src/caches/parentTypesCache.js
@@ -3,6 +3,10 @@ import AbstractQueuedCacheWithPostcheck from './AbstractQueuedCacheWithPostcheck
 const TYPE = 'PARENTTYPES';
 
 class ParentTypesCache extends AbstractQueuedCacheWithPostcheck {
+  SPARQL_ENDPOINT = 'https://query.wikidata.org/sparql';
+  ENTITY_URL_PREFIX = 'http://www.wikidata.org/entity/';
+  ENTITY_PREFIX = 'wd:';
+  SUBCLASS_PROP = 'wdt:P279';
 
   constructor() {
     super( TYPE, true, 1 );
@@ -13,8 +17,8 @@ class ParentTypesCache extends AbstractQueuedCacheWithPostcheck {
   }
 
   buildRequestPromice( [ typeId ] ) {
-    const url = 'https://query.wikidata.org/sparql?query='
-      + encodeURIComponent( 'SELECT DISTINCT ?type WHERE { wd:' + typeId + ' wdt:P279* ?type . }' );
+    const url = this.SPARQL_ENDPOINT + '?query='
+      + encodeURIComponent( `SELECT DISTINCT ?type WHERE { ${this.ENTITY_PREFIX}${typeId} ${this.SUBCLASS_PROP}* ?type . }` );
     return fetch( url, {
       headers: {
         Accept: 'application/sparql-results+json',
@@ -32,10 +36,10 @@ class ParentTypesCache extends AbstractQueuedCacheWithPostcheck {
         throw new Error( 'SPARQL result column type must be \'uri\'' );
       }
       const { value } = binding[ columnName ];
-      if ( !value.startsWith( 'http://www.wikidata.org/entity/Q' ) ) {
-        throw new Error( 'SPARQL result column value must start \'http://www.wikidata.org/entity/Q\'' );
+      if ( !value.startsWith( `${this.ENTITY_URL_PREFIX}Q` ) ) {
+        throw new Error( `SPARQL result column value must start '${this.ENTITY_URL_PREFIX}Q'` );
       }
-      return value.substr( 'http://www.wikidata.org/entity/'.length );
+      return value.substr( this.ENTITY_URL_PREFIX.length );
     } );
 
     /* eslint no-undef: 0 */

--- a/src/caches/propertiesBySparqlCache.js
+++ b/src/caches/propertiesBySparqlCache.js
@@ -4,6 +4,9 @@ const TYPE = 'PROPERTIESBYSPARQL';
 
 class PropertiesBySparqlCache extends AbstractQueuedCacheWithPostcheck {
 
+  SPARQL_ENDPOINT = 'https://query.wikidata.org/sparql';
+  ENTITY_URL_PREFIX = 'http://www.wikidata.org/entity/';
+
   constructor() {
     super( TYPE, true, 1 );
   }
@@ -13,7 +16,7 @@ class PropertiesBySparqlCache extends AbstractQueuedCacheWithPostcheck {
   }
 
   buildRequestPromice( cacheKeys ) {
-    const url = 'https://query.wikidata.org/sparql?query='
+    const url = this.SPARQL_ENDPOINT + '?query='
       + encodeURIComponent( cacheKeys[ 0 ] );
     return fetch( url, {
       headers: {
@@ -32,10 +35,10 @@ class PropertiesBySparqlCache extends AbstractQueuedCacheWithPostcheck {
         throw new Error( 'SPARQL result column type must be \'uri\'' );
       }
       const { value } = binding[ columnName ];
-      if ( !value.startsWith( 'http://www.wikidata.org/entity/P' ) ) {
-        throw new Error( 'SPARQL result column value must start \'http://www.wikidata.org/entity/P\'' );
+      if ( !value.startsWith( `${this.ENTITY_URL_PREFIX}P` ) ) {
+        throw new Error( `SPARQL result column value must start '${this.ENTITY_URL_PREFIX}P'` );
       }
-      return value.substr( 'http://www.wikidata.org/entity/'.length );
+      return value.substr( this.ENTITY_URL_PREFIX.length );
     } );
 
     /* eslint no-undef: 0 */

--- a/src/components/PropertyLabelCell.js
+++ b/src/components/PropertyLabelCell.js
@@ -9,11 +9,13 @@ export default class PropertyLabelCell extends PureComponent {
     propertyDescription: PropTypes.instanceOf( PropertyDescription ),
   }
 
+  WIKIDATA_LINK_URL = '//www.wikidata.org/wiki/';
+
   render() {
     const { label, description, id } = this.props.propertyDescription;
     return <th className={styles.wef_property_label}>
       <a
-        href={'//www.wikidata.org/wiki/Property:' + id}
+        href={`${this.WIKIDATA_LINK_URL}Property:${id}`}
         rel="noopener noreferrer"
         target="_blank"
         title={description}>

--- a/src/components/PropertyLabelCellById.js
+++ b/src/components/PropertyLabelCellById.js
@@ -10,6 +10,8 @@ export default class PropertyLabelCellById extends PureComponent {
     propertyId: PropTypes.string.isRequired,
   }
 
+  WIKIDATA_LINK_URL = '//www.wikidata.org/wiki/';
+
   render() {
     const { propertyId } = this.props;
 
@@ -18,7 +20,7 @@ export default class PropertyLabelCellById extends PureComponent {
         ? <PropertyLabelCell propertyDescription={cache[ propertyId ]} />
         : <th className={styles.wef_property_label}>
           <a
-            href={'//www.wikidata.org/wiki/Property:' + propertyId}
+            href={`${this.WIKIDATA_LINK_URL}Property:${propertyId}`}
             rel="noopener noreferrer"
             target="_blank">
             {propertyId}

--- a/src/components/dataValueEditors/UnsupportedDataValueEditor.js
+++ b/src/components/dataValueEditors/UnsupportedDataValueEditor.js
@@ -12,6 +12,8 @@ export default class UnsupportedDataValueEditor extends Component {
     propertyDescription: PropTypes.instanceOf( PropertyDescription ),
   }
 
+  WIKIDATA_ROOT = '//www.wikidata.org/';
+
   constructor() {
     super( ...arguments );
 
@@ -46,7 +48,7 @@ export default class UnsupportedDataValueEditor extends Component {
       generate: 'text/html',
     } ).then( result => {
       let html = result.result;
-      html = html.replace( 'href="/', 'href="//www.wikidata.org/' );
+      html = html.replace( 'href="/', 'href="' + this.WIKIDATA_ROOT );
       this.setState( { html } );
     } );
   }

--- a/src/components/dataValueEditors/quantity/UnitSelect.js
+++ b/src/components/dataValueEditors/quantity/UnitSelect.js
@@ -3,9 +3,9 @@ import EntityField from 'components/entityField';
 import PropertyDescription from 'core/PropertyDescription';
 import PropTypes from 'prop-types';
 
-const PREFIX = 'http://www.wikidata.org/entity/';
-
 export default class UnitSelect extends PureComponent {
+
+  ENTITY_URL_PREFIX = 'http://www.wikidata.org/entity/';
 
   static propTypes = {
     value: PropTypes.object,
@@ -22,6 +22,8 @@ export default class UnitSelect extends PureComponent {
     readOnly: false,
   }
 
+  ENTITY_URL_PREFIX = 'http://www.wikidata.org/entity/';
+
   constructor() {
     super( ...arguments );
 
@@ -33,7 +35,7 @@ export default class UnitSelect extends PureComponent {
       ...this.props.value,
       unit: !/^Q\d+$/.test( entityId )
         ? ''
-        : PREFIX + entityId,
+        : this.ENTITY_URL_PREFIX + entityId,
     } );
   }
 
@@ -41,8 +43,8 @@ export default class UnitSelect extends PureComponent {
     const { value, propertyDescription, readOnly } = this.props;
 
     const currentUnitStr = ( value || {} ).unit || '';
-    const currentEntityId = currentUnitStr && currentUnitStr.startsWith( PREFIX )
-      ? currentUnitStr.substr( PREFIX.length )
+    const currentEntityId = currentUnitStr && currentUnitStr.startsWith( this.ENTITY_URL_PREFIX )
+      ? currentUnitStr.substr( this.ENTITY_URL_PREFIX.length )
       : null;
 
     return <EntityField

--- a/src/components/dataValueEditors/wikibase-item/GoToWikidataButtonCell.js
+++ b/src/components/dataValueEditors/wikibase-item/GoToWikidataButtonCell.js
@@ -17,6 +17,8 @@ export default class GoToWikidataButtonCell extends PureComponent {
     entityId: null,
   };
 
+  WIKIDATA_LINK_URL = '//www.wikidata.org/wiki/';
+
   render() {
     const { disabled, entityId } = this.props;
 
@@ -24,7 +26,7 @@ export default class GoToWikidataButtonCell extends PureComponent {
       disabled={disabled || !entityId}
       icon="ui-icon-extlink"
       label={i18n.buttonOnWikidata}
-      onClick={NOOP}>{ children => <a href={entityId ? '//www.wikidata.org/wiki/' + entityId : '#'}
+      onClick={NOOP}>{ children => <a href={entityId ? this.WIKIDATA_LINK_URL + entityId : '#'}
         rel="noopener noreferrer"
         target="_blank">{children}</a> }</ButtonCell>;
   }

--- a/src/components/dataValueEditors/wikibase-item/WikibaseItemDataValueEditor.js
+++ b/src/components/dataValueEditors/wikibase-item/WikibaseItemDataValueEditor.js
@@ -25,6 +25,8 @@ export default class WikibaseItemDataValueEditor extends PureComponent {
     readOnly: false,
   }
 
+  WIKIDATA_LINK_URL = 'https://www.wikidata.org/wiki/';
+
   constructor() {
     super( ...arguments );
 
@@ -78,7 +80,7 @@ export default class WikibaseItemDataValueEditor extends PureComponent {
       return <td
         className={className + ' ' + styles[ 'wef_datavalue_' + WikibaseItemDataValueEditor.DATATYPE + '_readonly' ]}
         colSpan={12}>
-        { currentValue && <a href={'https://www.wikidata.org/wiki/' + currentValue}>
+        { currentValue && <a href={this.WIKIDATA_LINK_URL + currentValue}>
           <EntityLabel entityId={currentValue} />
         </a> }
       </td>;

--- a/src/components/entityField/index.js
+++ b/src/components/entityField/index.js
@@ -19,6 +19,8 @@ export default class EntityField extends PureComponent {
     readOnly: false,
   }
 
+  WIKIDATA_LINK_URL = 'https://www.wikidata.org/wiki/';
+
   constructor() {
     super( ...arguments );
 
@@ -75,7 +77,7 @@ export default class EntityField extends PureComponent {
 
     if ( readOnly ) {
       if ( value ) {
-        return <a href={'https://www.wikidata.org/wiki/' + value}>
+        return <a href={this.WIKIDATA_LINK_URL + value}>
           <EntityLabel entityId={value} />
         </a>;
       } else {

--- a/src/components/references/ReferencePropertySelect.js
+++ b/src/components/references/ReferencePropertySelect.js
@@ -13,6 +13,9 @@ export default class ReferencePropertySelect extends PureComponent {
     onSelect: PropTypes.func.isRequired,
   }
 
+  INSTANCE_OF = 'wdt:P31';
+  SOURCE_TYPE = 'wd:Q18608359';
+
   constructor() {
     super( ...arguments );
 
@@ -32,7 +35,7 @@ export default class ReferencePropertySelect extends PureComponent {
     // see https://www.wikidata.org/wiki/Q18608359
     return <PropertiesBySparqlProvider sparql={'SELECT DISTINCT ?property '
               + 'WHERE { '
-              + '?property wdt:P31 wd:Q18608359 . '
+              + `?property ${this.INSTANCE_OF} ${this.SOURCE_TYPE} . `
               + '}'}>
       { propertyIds => {
         if ( !propertyIds ) return <i>Loading possible reference properties...</i>;

--- a/src/core/ApiUtils.js
+++ b/src/core/ApiUtils.js
@@ -109,10 +109,12 @@ export function isCommons() {
   return WG_SITE_NAME === 'Wikimedia Commons';
 }
 
+const WIKIDATA_ROOT = '//www.wikidata.org/';
+
 function getWikidataApiImpl() {
   let api;
   if ( !isWikidata() ) {
-    api = new mw.ForeignApi( '//www.wikidata.org/w/api.php' );
+    api = new mw.ForeignApi( WIKIDATA_ROOT + 'w/api.php' );
   } else {
     api = new mw.Api();
   }

--- a/src/settings/EditorsLinks.js
+++ b/src/settings/EditorsLinks.js
@@ -13,6 +13,12 @@ export default class EditorLinks extends PureComponent {
     editorTemplates: PropTypes.arrayOf( PropTypes.shape( EditorShape ) ),
   }
 
+  SPARQL_ENDPOINT = 'https://query.wikidata.org/sparql';
+  ENTITY_URL_PREFIX = 'http://www.wikidata.org/entity/';
+  ENTITY_PREFIX = 'wd:';
+  INSTANCEOF_PROP = 'wdt:P31';
+  SUBCLASS_PROP = 'wdt:P279';
+
   constructor() {
     super( ...arguments );
     this.state = {
@@ -33,8 +39,8 @@ export default class EditorLinks extends PureComponent {
   }
 
   queryClassHierarchy( entityId ) {
-    const url = 'https://query.wikidata.org/sparql?query='
-      + encodeURIComponent( 'SELECT DISTINCT ?type WHERE { wd:' + entityId + ' wdt:P31 ?childClass . ?childClass wdt:P279* ?type }' );
+    const url = this.SPARQL_ENDPOINT + '?query='
+      + encodeURIComponent( `SELECT DISTINCT ?type WHERE { ${this.ENTITY_PREFIX}${entityId} ${this.INSTANCEOF_PROP} ?childClass . ?childClass ${this.SUBCLASS_PROP}* ?type }` );
     return fetch( url, {
       headers: {
         Accept: 'application/sparql-results+json',
@@ -46,7 +52,7 @@ export default class EditorLinks extends PureComponent {
 
         const classIds = result.results.bindings.map( binding => {
           const { value } = binding[ columnName ];
-          return value.substr( 'http://www.wikidata.org/entity/'.length );
+          return value.substr( this.ENTITY_URL_PREFIX.length );
         } );
         return classIds;
       } ).then( classIds => {


### PR DESCRIPTION
This is the first step of making it possible to run
this code on other, non-Wikidata-based sites (e.g. OSM wiki or Commons)

A follow-up is still needed to have a global site configuration,
preferably passable as a parameter to all classes that need it.

Note that in most cases the values are defined on instances, not static.
This should help with future per-instance configuration and testing.