### PR TITLE
Use wikibase item ID first if available

### DIFF
--- a/src/core/ApiUtils.js
+++ b/src/core/ApiUtils.js
@@ -38,13 +38,13 @@ export function getEntityIdDeferred() {
       return;
     }
 
-    if ( isWikidata() ) {
-      resolve( WG_TITLE );
+    if ( WG_WIKIBASE_ITEM_ID ) {
+      resolve( WG_WIKIBASE_ITEM_ID );
       return;
     }
 
-    if ( WG_WIKIBASE_ITEM_ID ) {
-      resolve( WG_WIKIBASE_ITEM_ID );
+    if ( isWikidata() ) {
+      resolve( WG_TITLE );
       return;
     }
 


### PR DESCRIPTION
In case this is used on a wikidata site, it should still
use the WG_WIKIBASE_ITEM_ID of the current page if it is
available. Otherwise, when viewing a regular wiki page
hosted on Wikidata, and that page has a sitelink to
an entity, the editor will attempt to use that page's
name with the wbgetentity, and will obviously fail.

In the future we may want to check if the page is
in an entity namespace too, and fail otherwise.