### PR TITLE
ExternalLinksEditorTemplate.js: add online accounts into online communities tab

### DIFF
--- a/src/editors/ExternalLinksEditorTemplate.js
+++ b/src/editors/ExternalLinksEditorTemplate.js
@@ -15,7 +15,7 @@ const editorDescription : EditorDefType = {
         { type: 'SparqlPropertyGroup',
           sparql: 'SELECT DISTINCT ?property '
                     + 'WHERE { '
-                    + '?property wdt:P31 wd:Q30041186 . ' /* Wikidata property related to online communities */
+                    + '?property wdt:P31/wdt:P279* wd:Q30041186 . ' /* Wikidata property related to online communities */
                     + '?property wikibase:propertyType wikibase:ExternalId . '
                     + '}' },
       ],


### PR DESCRIPTION
As online accounts are moved now into Q105388954 and it is a subclass of online communities (Q30041186), we need to take them out too.