### PR TITLE
Remove explicit action=tags API call

### DIFF
--- a/src/core/save.js
+++ b/src/core/save.js
@@ -7,7 +7,6 @@ import i18n from './i18n';
 import preSaveTransformations from './preSaveTransformations';
 
 const EMPTY_OBJECT : any = Object.freeze( {} );
-const SUMMARY_PREFIX : string = 'via [[:w:ru:ВП:WE-F|WE-Framework gadget]] from ';
 const TAG : string = 'WE-Framework gadget';
 
 const notifyOptions = {


### PR DESCRIPTION
As far as I can tell, it has not been needed since e365371f2d.

---

Context: I am [proposing](https://www.wikidata.org/wiki/Wikidata:Project_chat#Proposed_config_change:_remove_changetags_right_from_users) ([permalink](https://www.wikidata.org/w/index.php?title=Wikidata:Project_chat&oldid=1590287548#Proposed_config_change:_remove_changetags_right_from_users)) to remove the `changetags` right from most users on Wikidata, so this API call would start to fail.